### PR TITLE
Redirecting based on site config. #34

### DIFF
--- a/explorer/app/components/Redirect/Redirect.tsx
+++ b/explorer/app/components/Redirect/Redirect.tsx
@@ -1,0 +1,17 @@
+import { useRouter } from "next/router";
+import React, { useEffect } from "react";
+
+interface RedirectProps {
+  replace?: boolean;
+  destination: string;
+}
+
+export const Redirect: React.FC<RedirectProps> = ({ destination, replace }) => {
+  const router = useRouter();
+
+  useEffect(() => {
+    replace ? router.replace(destination) : router.push(destination);
+  }, [destination, replace, router]);
+
+  return <></>;
+};

--- a/explorer/app/components/Redirect/index.ts
+++ b/explorer/app/components/Redirect/index.ts
@@ -1,0 +1,1 @@
+export { Redirect } from "./Redirect";

--- a/explorer/app/components/index.ts
+++ b/explorer/app/components/index.ts
@@ -10,3 +10,4 @@ export * from "./NavLinks";
 export * from "./Search";
 export * from "./ProfileComponent";
 export * from "./SocialLinks";
+export * from "./Redirect";

--- a/explorer/app/config/model.ts
+++ b/explorer/app/config/model.ts
@@ -1,6 +1,7 @@
 import { HeaderProps } from "../components/Header/Header";
 
 export interface SiteConfig {
+  redirectRootToPath?: string;
   datasources: {
     catalog: "dcp2";
     url: string;

--- a/explorer/pages/index.tsx
+++ b/explorer/pages/index.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Redirect } from "../app/components";
+import { config } from "../app/config";
+
+const HomePage = () => {
+  const { redirectRootToPath } = config();
+
+  if (redirectRootToPath) {
+    return <Redirect destination={redirectRootToPath} replace />;
+  }
+
+  return <></>;
+};
+
+export default HomePage;

--- a/explorer/site-config/hca-dcp/dev/config.ts
+++ b/explorer/site-config/hca-dcp/dev/config.ts
@@ -1,6 +1,7 @@
 import { SiteConfig } from "../../../app/config/model";
 
 const config: SiteConfig = {
+  redirectRootToPath: "/explore/projects",
   datasources: {
     catalog: "dcp2",
     url: "https://service.dev.singlecell.gi.ucsc.edu/",

--- a/explorer/site-config/hca-dcp/prod/config.ts
+++ b/explorer/site-config/hca-dcp/prod/config.ts
@@ -1,6 +1,7 @@
 import { SiteConfig } from "../../../app/config/model";
 
 const config: SiteConfig = {
+  redirectRootToPath: "/explore/projects",
   datasources: {
     catalog: "dcp2",
     url: "https://service.dev.singlecell.gi.ucsc.edu/",

--- a/explorer/site-config/lungmap/dev/config.ts
+++ b/explorer/site-config/lungmap/dev/config.ts
@@ -1,6 +1,7 @@
 import { SiteConfig } from "../../../app/config/model";
 
 const config: SiteConfig = {
+  redirectRootToPath: "/explore/projects",
   datasources: {
     catalog: "dcp2",
     url: "https://service.dev.singlecell.gi.ucsc.edu/",

--- a/explorer/site-config/lungmap/prod/config.ts
+++ b/explorer/site-config/lungmap/prod/config.ts
@@ -1,6 +1,7 @@
 import { SiteConfig } from "../../../app/config/model";
 
 const config: SiteConfig = {
+  redirectRootToPath: "/explore/projects",
   datasources: {
     catalog: "dcp2",
     url: "https://service.dev.singlecell.gi.ucsc.edu/",


### PR DESCRIPTION
closes #34 


### Reviewers

### Changes
- Adding Redirect component
- Adding HomePage
- Adding redirectRootPathTo config property

### Definition of Done (from ticket)
If redirectRootToPath is specified, navigate to configured path (client-side redirect).
redirectRootToPath is optional: if not specified, no navigation is required.
For HCA, redirect to /explore/projects.
For LungMAP, redirect to /explore/projects.
No redirect required for AnVIL.

### Known Issues
