### PR TITLE
Adding Summary count and title. #118

### DIFF
--- a/explorer/app/components/ValueInline/valueInline.stories.tsx
+++ b/explorer/app/components/ValueInline/valueInline.stories.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { ValueInline } from "./valueInline";
+
+export default {
+  title: "Components/ValueInline",
+  component: ValueInline,
+} as ComponentMeta<typeof ValueInline>;
+
+const Template: ComponentStory<typeof ValueInline> = (args) => (
+  <ValueInline {...args} />
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  label: "Samples",
+  value: "610,561",
+};

--- a/explorer/app/components/ValueInline/valueInline.tsx
+++ b/explorer/app/components/ValueInline/valueInline.tsx
@@ -1,0 +1,25 @@
+import { Box } from "@mui/material";
+import React from "react";
+
+import { Text } from "../Text/Text";
+
+interface ValueInlineProps {
+  label: string;
+  value: string;
+}
+
+export const ValueInline = ({
+  label,
+  value,
+}: ValueInlineProps): JSX.Element => {
+  return (
+    <Box display="flex" gap={1}>
+      <Text variant="text-body-small-500" customColor="ink">
+        {value}
+      </Text>
+      <Text variant="text-body-small-400" customColor="inkLight">
+        {label}
+      </Text>
+    </Box>
+  );
+};

--- a/explorer/app/components/common/Stack/Stack.tsx
+++ b/explorer/app/components/common/Stack/Stack.tsx
@@ -12,6 +12,8 @@ interface Props {
   children: ReactNode | ReactNode[];
   direction?: StackProps["direction"];
   divider?: StackProps["divider"];
+  justifyContent?: StackProps["justifyContent"];
+  alignItems?: StackProps["alignItems"];
   gap?: number;
   spacing?: number;
 }
@@ -20,6 +22,8 @@ export const Stack = ({
   children,
   direction = "column",
   divider = undefined,
+  justifyContent,
+  alignItems,
   gap = 0,
   spacing = 0,
 }: Props): JSX.Element => {
@@ -27,6 +31,8 @@ export const Stack = ({
     <Stacker
       direction={direction}
       divider={divider}
+      justifyContent={justifyContent}
+      alignItems={alignItems}
       gap={gap}
       spacing={spacing}
     >

--- a/explorer/app/components/index.tsx
+++ b/explorer/app/components/index.tsx
@@ -18,3 +18,4 @@ export { Links } from "./Links/Links";
 export { Stack } from "./common/Stack/Stack";
 export { StatusBadge } from "./StatusBadge/statusBadge";
 export { Tooltip } from "./Tooltip/tooltip";
+export { ValueInline } from "./ValueInline/valueInline";

--- a/explorer/app/config/model.ts
+++ b/explorer/app/config/model.ts
@@ -58,6 +58,14 @@ export interface DetailConfig {
   top: ComponentConfig[];
 }
 
+/**
+ * Interface to determine the summary components and endpoint placed above the entities list.
+ */
+export interface SummaryConfig {
+  apiPath: string;
+  components: ComponentConfig[];
+}
+
 export interface ColumnConfig<
   T,
   C extends keyof JSX.IntrinsicElements | JSXElementConstructor<any> = any
@@ -81,5 +89,6 @@ export interface SiteConfig {
   layout: {
     header: HeaderProps;
   };
+  summary?: SummaryConfig;
   entities: EntityConfig[];
 }

--- a/explorer/app/entity/api/service.ts
+++ b/explorer/app/entity/api/service.ts
@@ -9,7 +9,7 @@ import {
   URL,
 } from "../../shared/constants";
 import { ListParams } from "../../models/params";
-import { ListResponseType } from "../../models/responses";
+import { ListResponseType, SummaryResponse } from "../../models/responses";
 
 /**
  * Request to get a list of entities.
@@ -72,5 +72,19 @@ export const detail = async (
   const res = await fetch(
     `${URL}${apiPath}/${id}?${convertUrlParams({ ...param })}`
   );
+  return await res.json();
+};
+
+/**
+ * Request to a single summary object that doesn't need id
+ * @param apiPath
+ * @param param
+ * @returns @see SummaryResponse
+ */
+export const summary = async (
+  apiPath: string,
+  param = DEFAULT_DETAIL_PARAMS
+): Promise<SummaryResponse> => {
+  const res = await fetch(`${URL}${apiPath}?${convertUrlParams({ ...param })}`);
   return await res.json();
 };

--- a/explorer/app/entity/list/ListContainer.tsx
+++ b/explorer/app/entity/list/ListContainer.tsx
@@ -9,13 +9,17 @@ import { useConfig } from "app/hooks/useConfig";
 import { useCurrentEntity } from "app/hooks/useCurrentEntity";
 import { useFetchEntities } from "app/hooks/useFetchEntities";
 import { ListModel } from "../../models/viewModels";
+import { ComponentCreator } from "app/components/ComponentCreator/ComponentCreator";
+import { useSummary } from "app/hooks/useSummary";
 
 export const ListContainer = (props: ListModel) => {
   const entity = useCurrentEntity();
-  const { entities } = useConfig();
+  const { entities, summary } = useConfig();
+  const { response: summaryResponse } = useSummary();
   const { response, isLoading, pagination } = useFetchEntities(props);
   const { asPath, push } = useRouter();
   const columnsConfig = entity?.list?.columns;
+  const summaryComponents = summary?.components;
 
   if (!columnsConfig || !entity) {
     return <span>EMPTY CONFIG</span>; //TODO: return the empty config UI component
@@ -51,6 +55,12 @@ export const ListContainer = (props: ListModel) => {
 
   return (
     <>
+      {summaryComponents && (
+        <ComponentCreator
+          components={summaryComponents}
+          response={summaryResponse}
+        />
+      )}
       <Tabs
         onTabChange={handleTabChanged}
         selectedTab={selectedTab}

--- a/explorer/app/hooks/useSummary.ts
+++ b/explorer/app/hooks/useSummary.ts
@@ -1,0 +1,38 @@
+import { SummaryResponse } from "./../models/responses";
+import { summary as loadSummary } from "app/entity/api/service";
+import { useEffect } from "react";
+import { useAsync } from "./useAsync";
+import { useConfig } from "./useConfig";
+
+interface UseSummaryResponse {
+  isLoading: boolean;
+  response?: SummaryResponse;
+}
+
+/**
+ * Hook responsible to handle the load of the values that will be used on listing page's summary.
+ * @returns an object with the loaded data and a flag indicating is the data is loading
+ */
+export const useSummary = (): UseSummaryResponse => {
+  const { summary } = useConfig();
+  const {
+    data: response,
+    isLoading: apiIsLoading,
+    run,
+  } = useAsync<SummaryResponse>();
+
+  useEffect(() => {
+    if (summary) {
+      run(loadSummary(summary.apiPath));
+    }
+  }, [run, summary]);
+
+  if (!summary) {
+    return { isLoading: false }; //TODO: return a summary placeholder
+  }
+
+  return {
+    response,
+    isLoading: apiIsLoading,
+  };
+};

--- a/explorer/app/models/responses.ts
+++ b/explorer/app/models/responses.ts
@@ -83,6 +83,7 @@ export interface FileResponse {
   }[];
 }
 
+// Anvil file
 export interface AnvilFileResponse {
   activities: {
     activity_type: string[];
@@ -109,6 +110,37 @@ export interface AnvilFileResponse {
     sourceId: string;
     sourceSpec: string;
   }[];
+}
+
+// Summary
+export interface SummaryResponse {
+  cellCountSummaries: {
+    countOfDocsWithOrganType: number;
+    organType: string[];
+    totalCellCountByOrgan: number;
+  }[];
+  donorCount: number;
+  fileCount: number;
+  fileTypeSummaries: {
+    count: number;
+    format: string;
+    matrixCellCount: number;
+    totalSize: number;
+  }[];
+  labCount: number;
+  organTypes: string[];
+  projectCount: number;
+  projects: {
+    cellSuspensions?: {
+      totalCells?: number;
+    };
+    projects: {
+      estimatedCellCount: number;
+    };
+  }[];
+  speciesCount: number;
+  specimenCount: number;
+  totalFileSize: number;
 }
 
 export interface ListResponseType<T = any> extends PaginatedResponse {

--- a/explorer/site-config/hca-dcp/dev/config.ts
+++ b/explorer/site-config/hca-dcp/dev/config.ts
@@ -6,6 +6,7 @@ import { SiteConfig } from "../../../app/config/model";
 import { projectEntity } from "./projectsEntity";
 import { samplesEntity } from "./samplesEntity";
 import { filesEntity } from "./filesEntity";
+import { summary } from "./summary";
 
 // Images
 import HcaLogo from "images/hca-logo.png";
@@ -24,6 +25,10 @@ const config: SiteConfig = {
       catalog: CATALOG_DCP2,
     },
     url: "https://service.dev.singlecell.gi.ucsc.edu/",
+  },
+  summary: {
+    apiPath: "index/summary",
+    components: summary,
   },
   entities: [projectEntity, filesEntity, samplesEntity],
   layout: {

--- a/explorer/site-config/hca-dcp/dev/summary.ts
+++ b/explorer/site-config/hca-dcp/dev/summary.ts
@@ -1,0 +1,45 @@
+import { ComponentConfig } from "app/config/model";
+import * as C from "../../../app/components";
+import * as T from "./summaryViewModelBuilder";
+
+export const summary = [
+  {
+    component: C.Stack,
+    props: {
+      direction: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+    },
+    children: [
+      {
+        component: C.Text,
+        transformer: T.title,
+      } as ComponentConfig<typeof C.Text>,
+      {
+        component: C.Stack,
+        props: {
+          direction: "row",
+          gap: 2,
+        },
+        children: [
+          {
+            component: C.ValueInline,
+            transformer: T.summaryToEstimatedCells,
+          } as ComponentConfig<typeof C.ValueInline>,
+          {
+            component: C.ValueInline,
+            transformer: T.summaryToSpecimens,
+          } as ComponentConfig<typeof C.ValueInline>,
+          {
+            component: C.ValueInline,
+            transformer: T.summaryToDonors,
+          } as ComponentConfig<typeof C.ValueInline>,
+          {
+            component: C.ValueInline,
+            transformer: T.summaryToFiles,
+          } as ComponentConfig<typeof C.ValueInline>,
+        ],
+      } as ComponentConfig<typeof C.Stack>,
+    ],
+  } as ComponentConfig<typeof C.Stack>,
+];

--- a/explorer/site-config/hca-dcp/dev/summaryViewModelBuilder.ts
+++ b/explorer/site-config/hca-dcp/dev/summaryViewModelBuilder.ts
@@ -1,0 +1,99 @@
+// Core dependencies
+import React from "react";
+
+// App dependencies
+import { SummaryResponse } from "app/models/responses";
+import * as C from "../../../app/components";
+
+const countFormatter = Intl.NumberFormat("en", { notation: "compact" });
+
+export const title = (): React.ComponentProps<typeof C.Text> => {
+  return {
+    variant: "text-heading-large",
+    customColor: "ink",
+    children: "Explore Data: DCP 2.0 Data View",
+  };
+};
+
+export const summaryToEstimatedCells = (
+  summary?: SummaryResponse
+): React.ComponentProps<typeof C.ValueInline> => {
+  if (!summary) {
+    return {
+      label: "Estimated Cells",
+      value: "0",
+    };
+  }
+
+  const projects = summary.projects ?? [];
+  const estimatedCells = projects.reduce(
+    (acc, { cellSuspensions, projects }) => {
+      if (
+        projects &&
+        (projects.estimatedCellCount || projects.estimatedCellCount === 0)
+      ) {
+        acc += projects.estimatedCellCount;
+      } else if (
+        cellSuspensions &&
+        (cellSuspensions.totalCells || cellSuspensions.totalCells === 0)
+      ) {
+        acc += cellSuspensions.totalCells;
+      }
+      return acc;
+    },
+    0
+  );
+
+  return {
+    label: "Estimated Cells",
+    value: `${countFormatter.format(estimatedCells)}`,
+  };
+};
+
+export const summaryToSpecimens = (
+  summary?: SummaryResponse
+): React.ComponentProps<typeof C.ValueInline> => {
+  if (!summary) {
+    return {
+      label: "Specimens",
+      value: "0",
+    };
+  }
+
+  return {
+    label: "Specimens",
+    value: `${countFormatter.format(summary.specimenCount)}`,
+  };
+};
+
+export const summaryToDonors = (
+  summary?: SummaryResponse
+): React.ComponentProps<typeof C.ValueInline> => {
+  if (!summary) {
+    return {
+      label: "Donors",
+      value: "0",
+    };
+  }
+
+  return {
+    label: "Donors",
+    value: `${countFormatter.format(summary.donorCount)}`,
+  };
+};
+
+export const summaryToFiles = (
+  summary?: SummaryResponse
+): React.ComponentProps<typeof C.ValueInline> => {
+  if (!summary) {
+    return {
+      label: "Files",
+      value: "0",
+    };
+  }
+
+  return {
+    label: "Files",
+    value: `${countFormatter.format(summary.fileCount)}`,
+  };
+};


### PR DESCRIPTION
closes #118 

### Reviewers

### Changes
- adding ValueInline component
- adding summery config

### Definition of Done (from ticket)
- Summary counts (estimated cells, specimens, donors and files) are displayed above each entity list (exact positioning and styling is out of scope for this ticket).
- Summary counts are formatted with a scale.


### QA steps (optional)

### Known Issues
