### PR TITLE
Update citation component to match refined mocks. #89.

### DIFF
--- a/explorer/.storybook/main.js
+++ b/explorer/.storybook/main.js
@@ -19,6 +19,8 @@ module.exports = {
         ...config.resolve,
         alias: {
           ...config.resolve.alias,
+          "app": path.resolve(__dirname, "../app"),
+          "images": path.resolve(__dirname, "../images"),
           "@emotion/core": toPath("node_modules/@emotion/react"),
           "emotion-theming": toPath("node_modules/@emotion/react"),
         },

--- a/explorer/app/components/Header/components/ProfileComponent/profileComponent.tsx
+++ b/explorer/app/components/Header/components/ProfileComponent/profileComponent.tsx
@@ -1,5 +1,5 @@
 // Core dependencies
-import LoginIcon from "@mui/icons-material/Login";
+import LoginRoundedIcon from "@mui/icons-material/LoginRounded";
 import { Button, IconButton } from "@mui/material";
 import React from "react";
 
@@ -18,12 +18,12 @@ export const ProfileComponent = (): JSX.Element => {
   return (
     <>
       {desktop ? (
-        <Button startIcon={<LoginIcon />} variant="nav">
+        <Button startIcon={<LoginRoundedIcon />} variant="nav">
           Sign in
         </Button>
       ) : (
         <IconButton color="ink">
-          <LoginIcon />
+          <LoginRoundedIcon />
         </IconButton>
       )}
     </>

--- a/explorer/app/components/Header/header.tsx
+++ b/explorer/app/components/Header/header.tsx
@@ -1,6 +1,6 @@
 // Core dependencies
-import MenuIcon from "@mui/icons-material/Menu";
-import CloseIcon from "@mui/icons-material/Close";
+import CloseRoundedIcon from "@mui/icons-material/CloseRounded";
+import MenuRoundedIcon from "@mui/icons-material/MenuRounded";
 import {
   AppBar,
   Box,
@@ -153,7 +153,7 @@ export const Header = ({
                 color="ink"
                 onClick={() => setDrawerOpen((open) => !open)}
               >
-                {drawerOpen ? <CloseIcon /> : <MenuIcon />}
+                {drawerOpen ? <CloseRoundedIcon /> : <MenuRoundedIcon />}
               </IconButton>
             )}
           </Box>

--- a/explorer/app/components/Links/components/Link/link.tsx
+++ b/explorer/app/components/Links/components/Link/link.tsx
@@ -1,0 +1,37 @@
+// Core dependencies
+import { Link as MLink } from "@mui/material";
+import NLink from "next/link";
+import React, { ReactNode } from "react";
+
+// App dependencies
+import { CopyToClipboard } from "../../../common/CopyToClipboard/copyToClipboard";
+
+export enum ANCHOR_TARGET {
+  BLANK = "_blank",
+  SELF = "_self",
+}
+
+interface Props {
+  copyable?: boolean;
+  label: ReactNode /* link label may be an element */;
+  target?: ANCHOR_TARGET;
+  url: string;
+}
+
+export const Link = ({
+  copyable = false,
+  label,
+  target = ANCHOR_TARGET.SELF,
+  url,
+}: Props): JSX.Element => {
+  return (
+    <>
+      <NLink href={url} passHref>
+        <MLink rel="noopener" target={target}>
+          {label}
+        </MLink>
+      </NLink>
+      {copyable && <CopyToClipboard copyStr={url} />}
+    </>
+  );
+};

--- a/explorer/app/components/Project/common/projectTransformer.ts
+++ b/explorer/app/components/Project/common/projectTransformer.ts
@@ -3,6 +3,19 @@ import { ProjectResponse } from "app/models/responses";
 import { Contact } from "../components/Contacts/contacts";
 
 /**
+ * Builds project citation path from projectId.
+ * @param project - Project response model return from API.
+ * @returns string representation of project citation path.
+ */
+export function buildProjectCitationPath(project?: ProjectResponse): string {
+  if (!project) {
+    return "";
+  }
+
+  return `explore/projects/${project.projects[0].projectId}`;
+}
+
+/**
  * Maps project contacts from API response.
  * @param project - Project response model return from API.
  * @returns project contacts.

--- a/explorer/app/components/Project/components/Citation/citation.stories.tsx
+++ b/explorer/app/components/Project/components/Citation/citation.stories.tsx
@@ -1,0 +1,23 @@
+// Core dependencies
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+// App dependencies
+import { Citation } from "./citation";
+
+export default {
+  argTypes: {
+    citationPath: { control: "text" },
+  },
+  component: Citation,
+  title: "Project/Detail",
+} as ComponentMeta<typeof Citation>;
+
+const Template: ComponentStory<typeof Citation> = (args) => (
+  <Citation {...args} />
+);
+
+export const ProjectCitation = Template.bind({});
+ProjectCitation.args = {
+  citationPath: "explore/projects/60ea42e1-af49-42f5-8164-d641fdb696bc",
+};

--- a/explorer/app/components/Project/components/Citation/citation.styles.ts
+++ b/explorer/app/components/Project/components/Citation/citation.styles.ts
@@ -1,0 +1,12 @@
+import styled from "@emotion/styled";
+
+export const CitationLink = styled.div`
+  white-space: nowrap;
+
+  // Copy icon button
+  & button {
+    bottom: 2px; /* Center aligns icon with link text without affecting overall rendered citation link height */
+    margin-left: 8px;
+    position: relative;
+  }
+`;

--- a/explorer/app/components/Project/components/Citation/citation.tsx
+++ b/explorer/app/components/Project/components/Citation/citation.tsx
@@ -1,0 +1,49 @@
+// Core dependencies
+import { Typography } from "@mui/material";
+import React from "react";
+
+// App dependencies
+import { useConfig } from "app/hooks/useConfig";
+import { Stack } from "../../../common/Stack/Stack";
+import { ANCHOR_TARGET, Link } from "../../../Links/components/Link/link";
+import { Section } from "../Section/section";
+
+// Styles
+import { CitationLink } from "./citation.styles";
+
+interface Props {
+  citationPath: string;
+}
+
+export const Citation = ({ citationPath }: Props): JSX.Element => {
+  const { datasources } = useConfig();
+  const { url } = datasources;
+  const citationLink = `${url}${citationPath}`;
+  const [root, projectId] = citationPath.split(/\/(?!.*\/)/);
+  const CitationLinkLabel = (
+    <>
+      {url}
+      <wbr />
+      {root}
+      <wbr />
+      {projectId}
+    </>
+  );
+  return (
+    <Section collapsable title="Citation">
+      <Stack gap={1}>
+        <Typography>
+          To reference this project, please use the following link:
+        </Typography>
+        <CitationLink>
+          <Link
+            copyable
+            label={CitationLinkLabel}
+            target={ANCHOR_TARGET.BLANK}
+            url={citationLink}
+          />
+        </CitationLink>
+      </Stack>
+    </Section>
+  );
+};

--- a/explorer/app/components/Project/components/DataReleasePolicy/dataReleasePolicy.tsx
+++ b/explorer/app/components/Project/components/DataReleasePolicy/dataReleasePolicy.tsx
@@ -9,7 +9,7 @@ import { Section } from "../Section/section";
 export const DataReleasePolicy = (): JSX.Element => {
   return (
     <Section title="Data Release Policy">
-      <Typography variant="inherit">
+      <Typography>
         For information regarding data sharing and data use, please see our{" "}
         <Link
           href="https://www.humancellatlas.org/data-release-policy/"

--- a/explorer/app/components/Project/components/Description/description.tsx
+++ b/explorer/app/components/Project/components/Description/description.tsx
@@ -12,7 +12,7 @@ interface Props {
 export const Description = ({ projectDescription }: Props): JSX.Element => {
   return (
     <Section title={"Description"}>
-      <Typography variant="inherit">{projectDescription}</Typography>
+      <Typography>{projectDescription}</Typography>
     </Section>
   );
 };

--- a/explorer/app/components/Project/components/Section/section.tsx
+++ b/explorer/app/components/Project/components/Section/section.tsx
@@ -1,6 +1,6 @@
 // Core dependencies
-import RemoveIcon from "@mui/icons-material/Remove";
-import AddIcon from "@mui/icons-material/Add";
+import AddRoundedIcon from "@mui/icons-material/AddRounded";
+import RemoveRoundedIcon from "@mui/icons-material/RemoveRounded";
 import { Collapse } from "@mui/material";
 import { CollapseProps } from "@mui/material/Collapse/Collapse";
 import React, { ReactNode, useEffect, useState } from "react";
@@ -39,7 +39,7 @@ export const Section = ({
   const [transitionDuration, setTransitionDuration] =
     useState<CollapseProps["timeout"]>(0);
   const disabled = !mobile || !collapsable;
-  const ExpandIcon = expanded ? RemoveIcon : AddIcon;
+  const ExpandIcon = expanded ? RemoveRoundedIcon : AddRoundedIcon;
   const SectionContent = (
     <Content variant="text-body-400-2lines">{children}</Content>
   );

--- a/explorer/app/components/Project/project.stories.tsx
+++ b/explorer/app/components/Project/project.stories.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { ComponentStory, ComponentMeta } from "@storybook/react";
 
 // App dependencies
+import { ProjectCitation } from "./components/Citation/citation.stories";
 import { ProjectContacts } from "./components/Contacts/contacts.stories";
 import { ProjectDataReleasePolicy } from "./components/DataReleasePolicy/dataReleasePolicy.stories";
 import { ProjectDescription } from "./components/Description/description.stories";
@@ -33,6 +34,9 @@ View.args = {
         }
       />
       <ProjectContacts contacts={ProjectContacts.args?.contacts || []} />
+      <ProjectCitation
+        citationPath={ProjectCitation.args?.citationPath || ""}
+      />
       <ProjectDataReleasePolicy />
     </>
   ),

--- a/explorer/app/components/common/CopyToClipboard/copyToClipboard.tsx
+++ b/explorer/app/components/common/CopyToClipboard/copyToClipboard.tsx
@@ -1,0 +1,46 @@
+// Core dependencies
+import copy from "copy-to-clipboard";
+import ContentCopyRoundedIcon from "@mui/icons-material/ContentCopyRounded";
+import { IconButton, Tooltip } from "@mui/material";
+import React, { useEffect } from "react";
+
+interface Props {
+  copyStr: string;
+}
+
+export const CopyToClipboard = ({ copyStr }: Props): JSX.Element => {
+  const [showTooltip, setShowTooltip] = React.useState(false);
+
+  /**
+   * Copies string to clipboard and sets showTooltip state to true.
+   * @param str
+   */
+  const onCopyToClipboard = (str: string): void => {
+    copy(str);
+    setShowTooltip(true);
+  };
+
+  // Timer to auto close the tooltip - the state showTooltip is set to false after a specified time (2 seconds).
+  useEffect(() => {
+    if (showTooltip) {
+      const tooltipTimeout = setTimeout(() => {
+        setShowTooltip(false);
+      }, 2000);
+      return () => clearTimeout(tooltipTimeout);
+    }
+  }, [showTooltip]);
+
+  return (
+    <Tooltip
+      arrow
+      disableHoverListener
+      open={showTooltip}
+      placement="top"
+      title={"Link Copied"}
+    >
+      <IconButton onClick={() => onCopyToClipboard(copyStr)} size="xxsmall">
+        <ContentCopyRoundedIcon color="primary" fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/explorer/app/components/common/Paper/paper.styles.ts
+++ b/explorer/app/components/common/Paper/paper.styles.ts
@@ -18,12 +18,12 @@ export const FlatPaper = styled(Paper)`
 export const RoundedPaper = styled(Paper)`
   border-radius: 8px;
 
-  & :first-of-type {
+  & > :first-of-type {
     border-top-left-radius: 8px;
     border-top-right-radius: 8px;
   }
 
-  & :last-of-type {
+  & > :last-of-type {
     border-bottom-left-radius: 8px;
     border-bottom-right-radius: 8px;
   }

--- a/explorer/app/components/index.tsx
+++ b/explorer/app/components/index.tsx
@@ -3,6 +3,7 @@ export { Citations } from "./Citations/Citations";
 export { FileCounts } from "./FileCounts/FileCounts";
 export { IconList } from "./IconList/IconList";
 export { StaticImage } from "./common/StaticImage/staticImage";
+export { Citation } from "./Project/components/Citation/citation";
 export { Contacts } from "./Project/components/Contacts/contacts";
 export { DataReleasePolicy } from "./Project/components/DataReleasePolicy/dataReleasePolicy";
 export { Description } from "./Project/components/Description/description";

--- a/explorer/app/theme/definitions.d.ts
+++ b/explorer/app/theme/definitions.d.ts
@@ -133,6 +133,7 @@ declare module "@mui/material/IconButton" {
   interface IconButtonPropsSizeOverrides {
     xlarge: true;
     xsmall: true;
+    xxsmall: true;
   }
 }
 

--- a/explorer/app/theme/theme.ts
+++ b/explorer/app/theme/theme.ts
@@ -267,6 +267,14 @@ export const theme = createTheme(defaultTheme, {
             marginRight: -2,
           },
         },
+        {
+          props: {
+            size: "xxsmall",
+          },
+          style: {
+            padding: 0,
+          },
+        },
       ],
     },
     MuiLink: {
@@ -304,6 +312,25 @@ export const theme = createTheme(defaultTheme, {
             paddingRight: 16,
           },
         },
+      },
+    },
+    MuiTooltip: {
+      styleOverrides: {
+        arrow: {
+          color: defaultTheme.palette.ink,
+        },
+        tooltip: {
+          ...defaultTheme.typography["text-body-small-400"],
+          backgroundColor: defaultTheme.palette.ink,
+          boxShadow:
+            "0px 8px 8px -4px rgb(16 24 40 / 0.03), 0px 20px 24px -4px rgb(16 24 40 / 0.08)",
+          padding: "8px 12px",
+        },
+      },
+    },
+    MuiTypography: {
+      defaultProps: {
+        variant: "inherit",
       },
     },
   },

--- a/explorer/site-config/hca-dcp/dev/mainColumn.ts
+++ b/explorer/site-config/hca-dcp/dev/mainColumn.ts
@@ -1,5 +1,5 @@
 // App dependencies
-import * as C from "../../../app/components";
+import * as C from "app/components";
 import { ComponentConfig } from "app/config/model";
 import { ProjectResponse } from "app/models/responses";
 import * as T from "./projectViewModelBuilder";
@@ -50,32 +50,9 @@ export const mainColumn = [
     ],
   } as ComponentConfig<typeof C.Section, ProjectResponse>,
   {
-    component: C.Section,
-    props: {
-      title: "Citation",
-    },
-    children: [
-      {
-        component: C.Stack,
-        props: {
-          gap: 1,
-        },
-        children: [
-          {
-            component: C.Text,
-            transformer: T.projectsToCitationsLabel,
-          } as ComponentConfig<typeof C.Text>,
-          {
-            component: C.Links,
-            props: {
-              showCopyButton: true,
-            },
-            transformer: T.projectsToCitations,
-          } as ComponentConfig<typeof C.Links>,
-        ],
-      } as ComponentConfig<typeof C.Stack>,
-    ],
-  } as ComponentConfig<typeof C.Section, ProjectResponse>,
+    component: C.Citation,
+    transformer: T.projectsToCitation,
+  } as ComponentConfig<typeof C.Citation, ProjectResponse>,
   {
     component: C.Section,
     props: {

--- a/explorer/site-config/hca-dcp/dev/projectViewModelBuilder.ts
+++ b/explorer/site-config/hca-dcp/dev/projectViewModelBuilder.ts
@@ -2,11 +2,12 @@
 import React from "react";
 
 // App dependencies
-import * as C from "../../../app/components";
+import * as C from "app/components";
 import {
+  buildProjectCitationPath,
   getProjectContacts,
   getProjectDescription,
-} from "../../../app/components/Project/common/projectTransformer";
+} from "app/components/Project/common/projectTransformer";
 import { STATUS } from "app/components/StatusBadge/statusBadge";
 import { ProjectResponse } from "app/models/responses";
 import { ENTRIES } from "app/project-edits";
@@ -363,26 +364,11 @@ export const projectsToSupplementaryLinksLabel = (): React.ComponentProps<
   };
 };
 
-export const projectsToCitationsLabel = (): React.ComponentProps<
-  typeof C.Text
-> => {
-  return {
-    variant: "text-body-400-2lines",
-    customColor: "ink",
-    children: `To reference this project, please use the following link:`,
-  };
-};
-
-export const projectsToCitations = (
+export const projectsToCitation = (
   project: ProjectResponse
-): React.ComponentProps<typeof C.Links> => {
+): React.ComponentProps<typeof C.Citation> => {
   return {
-    links: [
-      {
-        label: `https://data.humancellatlas.org/explore/projects/${project.projects[0].projectId}`,
-        url: `https://data.humancellatlas.org/explore/projects/${project.projects[0].projectId}`,
-      },
-    ],
+    citationPath: buildProjectCitationPath(project),
   };
 };
 


### PR DESCRIPTION
### Reviewers

#89 

@MillenniumFalconMechanic 

### Changes
- created `Citation` component to match refined mocks.
- updated citation stories.
- updated storybook to support the use of alias for component imports.
- replaced all icons to "rounded" in any "touched" (i.e. "finalised" components).
- modified `Link` component for links with copy icon.
- created common `CopyToClipboard` component.
- updated Typography default prop `variant` to `inherit` and removed unnecessary use of this variant.
- css bug fix on customer styled `Paper` component.
