### PR TITLE
Config entity lists for hca and lungmap. #76

### DIFF
--- a/explorer/app/models/responses.ts
+++ b/explorer/app/models/responses.ts
@@ -63,11 +63,21 @@ export interface ProjectResponse {
 
 //Samples
 export interface SampleResponse {
+  protocols: {
+    libraryConstructionApproach: string[];
+  }[];
   projects: {
     projectTitle: string[];
+    estimatedCellCount?: number;
+  }[];
+  donorOrganisms: {
+    genusSpecies: string[];
+    disease: string[];
   }[];
   samples: {
     id: string;
+    sampleEntityType: string;
+    organ: string;
   }[];
 }
 
@@ -75,11 +85,14 @@ export interface SampleResponse {
 export interface FileResponse {
   projects: {
     projectTitle: string[];
+    estimatedCellCount?: number;
   }[];
   files: {
     name: string;
     uuid: string;
     format: string;
+    size: number;
+    contentDescription: string[];
   }[];
 }
 

--- a/explorer/app/utils/fileSize.ts
+++ b/explorer/app/utils/fileSize.ts
@@ -1,0 +1,13 @@
+/**
+ * Format bytes as human-readable text.
+ * @param size;
+ * @returns human-readable size
+ */
+export const humanFileSize = (size: number): string => {
+  const i = Math.floor(Math.log(size) / Math.log(1024));
+  return (
+    Number((size / Math.pow(1024, i)).toFixed(2)) * 1 +
+    " " +
+    ["B", "kB", "MB", "GB", "TB"][i]
+  );
+};

--- a/explorer/site-config/hca-dcp/dev/fileTransformer.ts
+++ b/explorer/site-config/hca-dcp/dev/fileTransformer.ts
@@ -1,6 +1,9 @@
 import { concatStrings } from "app/utils/string";
 import { FileResponse } from "app/models/responses";
 import * as C from "../../../app/components";
+import { humanFileSize } from "app/utils/fileSize";
+
+const formatter = Intl.NumberFormat("en", { notation: "compact" });
 
 export const filesToFileNameColumn = (
   file: FileResponse
@@ -44,6 +47,52 @@ export const filesToProjTitleColumn = (
 
   return {
     children: concatStrings(file.projects[0].projectTitle),
+    variant: "text-body-400",
+    customColor: "ink",
+  };
+};
+
+export const filesToFileSizeColumn = (
+  file: FileResponse
+): React.ComponentProps<typeof C.Text> => {
+  if (!file.files?.[0]) {
+    return {};
+  }
+
+  return {
+    children: humanFileSize(file.files[0].size),
+    variant: "text-body-400",
+    customColor: "ink",
+  };
+};
+
+export const filesToContentDescColumn = (
+  file: FileResponse
+): React.ComponentProps<typeof C.Text> => {
+  if (!file.files?.[0]) {
+    return {};
+  }
+
+  return {
+    children: concatStrings(file.files[0].contentDescription),
+    variant: "text-body-400",
+    customColor: "ink",
+  };
+};
+
+export const filesToCellCountColumn = (
+  file: FileResponse
+): React.ComponentProps<typeof C.Text> => {
+  if (!file.projects?.[0].estimatedCellCount) {
+    return {
+      children: 0,
+      variant: "text-body-400",
+      customColor: "ink",
+    };
+  }
+
+  return {
+    children: formatter.format(file.projects[0].estimatedCellCount),
     variant: "text-body-400",
     customColor: "ink",
   };

--- a/explorer/site-config/hca-dcp/dev/filesEntity.ts
+++ b/explorer/site-config/hca-dcp/dev/filesEntity.ts
@@ -31,10 +31,31 @@ export const filesEntity: EntityConfig<FileResponse> = {
         } as ComponentConfig<typeof C.Text>,
       },
       {
+        header: "File Size",
+        componentConfig: {
+          component: C.Text,
+          transformer: T.filesToFileSizeColumn,
+        } as ComponentConfig<typeof C.Text>,
+      },
+      {
+        header: "Content Description",
+        componentConfig: {
+          component: C.Text,
+          transformer: T.filesToContentDescColumn,
+        } as ComponentConfig<typeof C.Text>,
+      },
+      {
         header: "Project Title",
         componentConfig: {
           component: C.Text,
           transformer: T.filesToProjTitleColumn,
+        } as ComponentConfig<typeof C.Text>,
+      },
+      {
+        header: "Cell Count Estimate",
+        componentConfig: {
+          component: C.Text,
+          transformer: T.filesToCellCountColumn,
         } as ComponentConfig<typeof C.Text>,
       },
     ],

--- a/explorer/site-config/hca-dcp/dev/projectViewModelBuilder.ts
+++ b/explorer/site-config/hca-dcp/dev/projectViewModelBuilder.ts
@@ -12,6 +12,8 @@ import { ProjectResponse } from "app/models/responses";
 import { ENTRIES } from "app/project-edits";
 import { concatStrings } from "app/utils/string";
 
+const formatter = Intl.NumberFormat("en", { notation: "compact" });
+
 const getOrganizations = (project: ProjectResponse): string[] => {
   return Array.from(
     new Set(
@@ -285,8 +287,6 @@ export const projectsToCellCount = (
     return { label: "Cell Count Estimate", value: "None" };
   }
 
-  const formatter = Intl.NumberFormat("en", { notation: "compact" });
-
   return {
     label: "Cell Count Estimate",
     value: `${formatter.format(project.projects[0].estimatedCellCount)}`,
@@ -469,6 +469,53 @@ export const projectsToCellCountColumn = (
   return {
     variant: "text-body-400",
     customColor: "ink",
-    children: project.cellSuspensions[0].totalCells,
+    children: `${formatter.format(project.cellSuspensions[0].totalCells)}`,
+  };
+};
+
+export const projectsToLibConstApproachColumn = (
+  project: ProjectResponse
+): React.ComponentProps<typeof C.Text> => {
+  if (!project.protocols?.[0].libraryConstructionApproach) {
+    return {
+      children: "",
+    };
+  }
+
+  return {
+    children: concatStrings(project.protocols[0].libraryConstructionApproach),
+    variant: "text-body-400",
+    customColor: "ink",
+  };
+};
+
+export const projectsToAnatomicalEntityColumn = (
+  project: ProjectResponse
+): React.ComponentProps<typeof C.Text> => {
+  if (!project.samples?.[0]?.organ) {
+    return {
+      children: "",
+    };
+  }
+  return {
+    children: concatStrings(project.samples[0].organ),
+    variant: "text-body-400",
+    customColor: "ink",
+  };
+};
+
+export const projectsToDiseaseDonorColumn = (
+  project: ProjectResponse
+): React.ComponentProps<typeof C.Text> => {
+  if (!project.donorOrganisms?.[0]) {
+    return {
+      children: "",
+    };
+  }
+
+  return {
+    children: concatStrings(project.donorOrganisms[0].disease),
+    variant: "text-body-400",
+    customColor: "ink",
   };
 };

--- a/explorer/site-config/hca-dcp/dev/projectsEntity.ts
+++ b/explorer/site-config/hca-dcp/dev/projectsEntity.ts
@@ -39,6 +39,27 @@ export const projectEntity = {
         },
       },
       {
+        header: "Library Construction Approach",
+        componentConfig: {
+          component: C.Text,
+          transformer: T.projectsToLibConstApproachColumn,
+        },
+      },
+      {
+        header: "Anatomical Entity",
+        componentConfig: {
+          component: C.Text,
+          transformer: T.projectsToAnatomicalEntityColumn,
+        },
+      },
+      {
+        header: "Disease (Donor)",
+        componentConfig: {
+          component: C.Text,
+          transformer: T.projectsToDiseaseDonorColumn,
+        },
+      },
+      {
         header: "Cell Count Estimate",
         componentConfig: {
           component: C.Tooltip,

--- a/explorer/site-config/hca-dcp/dev/sampleTransformer.ts
+++ b/explorer/site-config/hca-dcp/dev/sampleTransformer.ts
@@ -2,6 +2,8 @@ import { SampleResponse } from "app/models/responses";
 import { concatStrings } from "app/utils/string";
 import * as C from "../../../app/components";
 
+const formatter = Intl.NumberFormat("en", { notation: "compact" });
+
 export const samplesToSampleIDColumn = (
   sample: SampleResponse
 ): React.ComponentProps<typeof C.Links> => {
@@ -30,6 +32,94 @@ export const samplesToProjTitleColumn = (
 
   return {
     children: concatStrings(sample.projects[0].projectTitle),
+    variant: "text-body-400",
+    customColor: "ink",
+  };
+};
+
+export const samplesToSpeciesColumn = (
+  sample: SampleResponse
+): React.ComponentProps<typeof C.Text> => {
+  if (!sample.donorOrganisms) {
+    return {};
+  }
+
+  return {
+    children: concatStrings(
+      sample.donorOrganisms.flatMap((orgnanism) => orgnanism.genusSpecies)
+    ),
+    variant: "text-body-400",
+    customColor: "ink",
+  };
+};
+
+export const samplesToSampleTypeColumn = (
+  sample: SampleResponse
+): React.ComponentProps<typeof C.Text> => {
+  if (!sample.samples?.[0]) {
+    return {};
+  }
+
+  return {
+    children: concatStrings(sample.samples[0].sampleEntityType),
+    variant: "text-body-400",
+    customColor: "ink",
+  };
+};
+
+export const samplesToLibConsApproachColumn = (
+  sample: SampleResponse
+): React.ComponentProps<typeof C.Text> => {
+  if (!sample.protocols?.[0]?.libraryConstructionApproach) {
+    return {};
+  }
+
+  return {
+    children: concatStrings(sample.protocols[0].libraryConstructionApproach),
+    variant: "text-body-400",
+    customColor: "ink",
+  };
+};
+
+export const samplesToAnatomicalEntityColumn = (
+  sample: SampleResponse
+): React.ComponentProps<typeof C.Text> => {
+  if (!sample.samples?.[0]?.organ) {
+    return {};
+  }
+
+  return {
+    children: concatStrings(sample.samples[0].organ),
+    variant: "text-body-400",
+    customColor: "ink",
+  };
+};
+export const samplesToDiseaseDonorColumn = (
+  sample: SampleResponse
+): React.ComponentProps<typeof C.Text> => {
+  if (!sample.donorOrganisms?.[0]) {
+    return {};
+  }
+
+  return {
+    children: concatStrings(sample.donorOrganisms[0].disease),
+    variant: "text-body-400",
+    customColor: "ink",
+  };
+};
+export const samplesToCellCountColumn = (
+  sample: SampleResponse
+): React.ComponentProps<typeof C.Text> => {
+  if (!sample.projects?.[0].estimatedCellCount) {
+    return {
+      children: 0,
+      variant: "text-body-400",
+      customColor: "ink",
+    };
+  }
+
+  return {
+    children: formatter.format(sample.projects[0].estimatedCellCount),
     variant: "text-body-400",
     customColor: "ink",
   };

--- a/explorer/site-config/hca-dcp/dev/samplesEntity.ts
+++ b/explorer/site-config/hca-dcp/dev/samplesEntity.ts
@@ -30,6 +30,48 @@ export const samplesEntity: EntityConfig<SampleResponse> = {
           transformer: T.samplesToProjTitleColumn,
         } as ComponentConfig<typeof C.Text>,
       },
+      {
+        header: "Species",
+        componentConfig: {
+          component: C.Text,
+          transformer: T.samplesToSpeciesColumn,
+        } as ComponentConfig<typeof C.Text>,
+      },
+      {
+        header: "Sample Type",
+        componentConfig: {
+          component: C.Text,
+          transformer: T.samplesToSampleTypeColumn,
+        } as ComponentConfig<typeof C.Text>,
+      },
+      {
+        header: "Library Construction Approach",
+        componentConfig: {
+          component: C.Text,
+          transformer: T.samplesToLibConsApproachColumn,
+        } as ComponentConfig<typeof C.Text>,
+      },
+      {
+        header: "Anatomical Entity",
+        componentConfig: {
+          component: C.Text,
+          transformer: T.samplesToAnatomicalEntityColumn,
+        } as ComponentConfig<typeof C.Text>,
+      },
+      {
+        header: "Disease (Donor)",
+        componentConfig: {
+          component: C.Text,
+          transformer: T.samplesToDiseaseDonorColumn,
+        } as ComponentConfig<typeof C.Text>,
+      },
+      {
+        header: "Cell Count Estimate",
+        componentConfig: {
+          component: C.Text,
+          transformer: T.samplesToCellCountColumn,
+        } as ComponentConfig<typeof C.Text>,
+      },
     ],
   } as ListConfig<SampleResponse>,
 };

--- a/explorer/site-config/lungmap/dev/config.ts
+++ b/explorer/site-config/lungmap/dev/config.ts
@@ -1,10 +1,12 @@
 // App dependencies
 import { ELEMENT_ALIGNMENT } from "../../../app/common/entities";
 import { SiteConfig } from "../../../app/config/model";
-import { getProjectId } from "app/transformers/hca";
 
 // Images
 import LungMapLogo from "images/lungmap-logo.png";
+
+// Config
+import hcaConfig from "site-config/hca-dcp/dev/config";
 
 const CATALOG_LM2 = "lm2";
 
@@ -20,25 +22,7 @@ const config: SiteConfig = {
     // url: "https://service.dev.singlecell.gi.ucsc.edu/",
     url: "https://service.azul.data.humancellatlas.org/",
   },
-  entities: [
-    {
-      label: "Projects",
-      apiPath: "index/projects",
-      route: "projects",
-      staticLoad: true,
-      getId: getProjectId,
-    },
-    {
-      label: "Files",
-      apiPath: "index/files",
-      route: "files",
-    },
-    {
-      label: "Samples",
-      apiPath: "index/samples",
-      route: "samples",
-    },
-  ],
+  entities: hcaConfig.entities,
   layout: {
     header: {
       authenticationEnabled: false,


### PR DESCRIPTION
Closes #76 

### Reviewers

### Changes
- add entities config fHCAhca and lungmap

### Definition of Done (from ticket)

### QA steps (optional)

### Known Issues


@MillenniumFalconMechanic Now that I had the chance to touch a little bit different types it's more clear the similarities between all of them. Maybe, sometime in the future, we can create smaller interfaces for the response types and try to use the `Extract` utility type to transform the model into component props. I think this might help the transformers' reusability. We can discuss more at our next meeting
