### PR TITLE
Exclude explorer/build from ESLint checks (#230)

### DIFF
--- a/explorer/.eslintignore
+++ b/explorer/.eslintignore
@@ -1,3 +1,5 @@
 **/node_modules/*
 **/out/*
 **/.next/*
+
+build


### PR DESCRIPTION
The directory was already excluded from Prettier checks