### PR TITLE
Apply filter components to filter functionality. #384.

### DIFF
--- a/explorer/app/components/Filter/components/Filter/filter.tsx
+++ b/explorer/app/components/Filter/components/Filter/filter.tsx
@@ -1,4 +1,5 @@
 // Core dependencies
+import { PopoverPosition } from "@mui/material";
 import React, { ElementType, MouseEvent, ReactNode, useState } from "react";
 
 // Styles
@@ -11,37 +12,41 @@ interface Props {
 }
 
 export const Filter = ({ content, tags, Target }: Props): JSX.Element => {
-  const [filterTargetEl, setFilterTargetEl] =
-    useState<HTMLButtonElement | null>(null);
+  const [openPopover, setOpenPopover] = useState<boolean>(false);
+  const [popoverPosition, setPopoverPosition] = useState<PopoverPosition>({
+    left: 0,
+    top: 0,
+  });
 
   /**
    * Closes filter popover.
-   * Sets filterTargetEl state to null.
    */
   const onCloseFilter = (): void => {
-    setFilterTargetEl(null);
+    setOpenPopover(false);
   };
 
   /**
-   * Opens filter popover.
-   * Sets filterTargetEl state to the current target for the specified event.
+   * Opens filter popover and sets popover position.
    * @param event - Mouse event interaction with filter target.
    */
   const onOpenFilter = (event: MouseEvent<HTMLButtonElement>): void => {
-    setFilterTargetEl(event.currentTarget);
+    // Grab the filter target size and position and calculate the popover position.
+    const targetDOMRect = event.currentTarget.getBoundingClientRect();
+    const popoverLeftPos = targetDOMRect.x;
+    const popoverTopPos = targetDOMRect.y + targetDOMRect.height;
+    // Set popover position and open state.
+    setPopoverPosition({ left: popoverLeftPos, top: popoverTopPos });
+    setOpenPopover(true);
   };
 
   return (
     <>
       <Target onClick={onOpenFilter} />
       <FilterPopover
-        anchorEl={filterTargetEl}
-        anchorOrigin={{
-          horizontal: "left",
-          vertical: "bottom",
-        }}
+        anchorPosition={{ ...popoverPosition }}
+        anchorReference="anchorPosition"
         onClose={onCloseFilter}
-        open={Boolean(filterTargetEl)}
+        open={openPopover}
         PaperProps={{ variant: "menu" }}
       >
         {content}

--- a/explorer/app/components/Filter/components/FilterMenu/filterMenu.styles.ts
+++ b/explorer/app/components/Filter/components/FilterMenu/filterMenu.styles.ts
@@ -17,6 +17,7 @@ export const FilterView = styled.div<Props>`
   .MuiList-root {
     max-height: ${MAX_LIST_HEIGHT_PX}px;
     overflow: auto;
+    overflow-wrap: break-word;
     padding: 8px 0;
   }
 
@@ -31,5 +32,9 @@ export const FilterView = styled.div<Props>`
     display: grid;
     gap: 8px;
     grid-template-columns: 1fr auto;
+
+    > span {
+      min-width: 0; /* required; flexbox child min-width property is "auto" by default making overflow-wrap ineffectual */
+    }
   }
 `;

--- a/explorer/app/components/Filter/components/FilterMenu/filterMenu.tsx
+++ b/explorer/app/components/Filter/components/FilterMenu/filterMenu.tsx
@@ -39,7 +39,7 @@ export const FilterMenu = ({
         {values.map(({ count, key, label, selected }) => (
           <ListItemButton
             key={key}
-            onClick={(): void => onFilter(categoryKey, key, selected)}
+            onClick={(): void => onFilter(categoryKey, key, !selected)}
             selected={selected}
           >
             <Checkbox

--- a/explorer/app/components/Filter/components/Filters/filters.tsx
+++ b/explorer/app/components/Filter/components/Filters/filters.tsx
@@ -34,7 +34,7 @@ function buildSelectCategoryTags(
     .map(({ key: categoryValueKey, label, selected }) => {
       return {
         label: label,
-        onRemove: () => onFilter(categoryKey, categoryValueKey, selected),
+        onRemove: () => onFilter(categoryKey, categoryValueKey, !selected),
         superseded: false,
       };
     });

--- a/explorer/app/views/Index/index.tsx
+++ b/explorer/app/views/Index/index.tsx
@@ -4,6 +4,10 @@ import React, { Fragment, useState } from "react";
 
 // App dependencies
 import {
+  AzulEntitiesStaticResponse,
+  AzulSummaryResponse,
+} from "../../apis/azul/common/entities";
+import {
   Tab,
   Tabs,
   TabsValue,
@@ -15,14 +19,12 @@ import { useConfig } from "app/hooks/useConfig";
 import { useCurrentEntity } from "app/hooks/useCurrentEntity";
 import { useFetchEntities } from "app/hooks/useFetchEntities";
 import { useSummary } from "app/hooks/useSummary";
+import { Filters } from "../../components/Filter/components/Filters/filters";
 import { Index as IndexView } from "../../components/Index/index";
-import {
-  AzulEntitiesStaticResponse,
-  AzulSummaryResponse,
-} from "../../apis/azul/common/entities";
-import { useCategoryFilter } from "../../hooks/useCategoryFilter";
+import { SidebarLabel } from "../../components/Layout/components/Sidebar/components/SidebarLabel/sidebarLabel";
 import { Sidebar } from "../../components/Layout/components/Sidebar/sidebar";
 import { EntityConfig, SummaryConfig } from "../../config/common/entities";
+import { useCategoryFilter } from "../../hooks/useCategoryFilter";
 
 /**
  * Returns tabs to be used as a prop for the Tabs component.
@@ -132,30 +134,8 @@ export const Index = (props: AzulEntitiesStaticResponse): JSX.Element => {
   return (
     <>
       {categoryViews && !!categoryViews.length && (
-        <Sidebar>
-          {categoryViews.map((categoryView, index) => (
-            <Fragment key={index}>
-              <div>
-                <b>{categoryView.label}</b>
-              </div>
-              {categoryView.values.map((categoryValueView, j) => (
-                <div
-                  key={j}
-                  onClick={(): void =>
-                    onFilter(
-                      categoryView.key,
-                      categoryValueView.key,
-                      !categoryValueView.selected
-                    )
-                  }
-                >
-                  {categoryValueView.selected ? <>&#9889;</> : null}{" "}
-                  {categoryValueView.label} {categoryValueView.count}
-                  {categoryValueView.selected ? <>&#9889;</> : null}
-                </div>
-              ))}
-            </Fragment>
-          ))}
+        <Sidebar Label={<SidebarLabel label={"Filters"} />}>
+          <Filters categories={categoryViews} onFilter={onFilter} />
         </Sidebar>
       )}
       <IndexView


### PR DESCRIPTION
### Ticket
Closes #384.

### Reviewers
@MillenniumFalconMechanic .

### Changes
- Added filter components to filter functionality.
- Modified filter menu list items style to handle words with non-breaking spaces.
- Modified onRemove and onFilter `selected` parameter to `!selected`.
- Modified `Filter` component popover props:
  - Removed the use of `anchorEl` to position popover. Selecting a term rerenders the `Filter` component and target element. For some reason, the reference to the original target element is lost and the popover fallback is for the popover to render with `anchorPosition` at left, top of viewport.
  - added `anchorPosition` to correctly position popover.

### Definition of Done (from ticket)

### QA steps (optional)

### Known Issues
