### PR TITLE
401 update hca dcp file entity list config

### DIFF
--- a/explorer/app/apis/azul/hca-dcp/common/entities.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/entities.ts
@@ -1,0 +1,16 @@
+/**
+ * Model of response returned from /index/files API endpoint.
+ */
+export interface FilesResponse {
+  files: {
+    contentDescription: string[];
+    format: string;
+    name: string;
+    size: number;
+    uuid: string;
+  }[];
+  projects: {
+    estimatedCellCount?: number;
+    projectTitle: string[];
+  }[];
+}

--- a/explorer/app/apis/azul/hca-dcp/common/transformers.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/transformers.ts
@@ -1,0 +1,28 @@
+import { FilesResponse } from "./entities";
+import { concatStrings } from "../../../../utils/string";
+import { humanFileSize } from "../../../../utils/fileSize";
+
+const formatter = Intl.NumberFormat("en", { notation: "compact" });
+
+export const filesToFileName = (file: FilesResponse): string =>
+  file.files[0].name;
+
+export const filesToFileFormat = (file: FilesResponse): string =>
+  file.files[0].format;
+
+export const filesToProjTitle = (file: FilesResponse): string =>
+  concatStrings(file.projects[0].projectTitle);
+
+export const filesToFileSize = (file: FilesResponse): string =>
+  humanFileSize(file.files[0].size);
+
+export const filesToContentDesc = (file: FilesResponse): string =>
+  concatStrings(file.files[0].contentDescription);
+
+export const filesToCellCount = (file: FilesResponse): string | undefined => {
+  if (file.projects[0].estimatedCellCount) {
+    return formatter.format(file.projects[0].estimatedCellCount);
+  } else {
+    return; //TODO: idk what to do here
+  }
+};

--- a/explorer/app/apis/azul/hca-dcp/common/transformers.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/transformers.ts
@@ -2,27 +2,20 @@ import { FilesResponse } from "./entities";
 import { concatStrings } from "../../../../utils/string";
 import { humanFileSize } from "../../../../utils/fileSize";
 
-const formatter = Intl.NumberFormat("en", { notation: "compact" });
-
 export const filesToFileName = (file: FilesResponse): string =>
-  file.files[0].name;
+  file.files[0].name ?? "";
 
 export const filesToFileFormat = (file: FilesResponse): string =>
-  file.files[0].format;
+  file.files[0].format ?? "";
 
 export const filesToProjTitle = (file: FilesResponse): string =>
-  concatStrings(file.projects[0].projectTitle);
+  concatStrings(file.projects[0].projectTitle) ?? "";
 
 export const filesToFileSize = (file: FilesResponse): string =>
-  humanFileSize(file.files[0].size);
+  humanFileSize(file.files[0].size) ?? "";
 
 export const filesToContentDesc = (file: FilesResponse): string =>
-  concatStrings(file.files[0].contentDescription);
+  concatStrings(file.files[0].contentDescription) ?? "";
 
-export const filesToCellCount = (file: FilesResponse): string | undefined => {
-  if (file.projects[0].estimatedCellCount) {
-    return formatter.format(file.projects[0].estimatedCellCount);
-  } else {
-    return; //TODO: idk what to do here
-  }
-};
+export const filesToCellCount = (file: FilesResponse): number =>
+  file.projects[0].estimatedCellCount ?? 0;

--- a/explorer/app/models/responses.ts
+++ b/explorer/app/models/responses.ts
@@ -19,23 +19,6 @@ export interface FileFormatResponse {
 }
 
 /**
- * Model of response returned from /index/files API endpoint.
- */
-export interface FilesResponse {
-  files: {
-    contentDescription: string[];
-    format: string;
-    name: string;
-    size: number;
-    uuid: string;
-  }[];
-  projects: {
-    estimatedCellCount?: number;
-    projectTitle: string[];
-  }[];
-}
-
-/**
  * Model of project value nested in response returned from index/projects API endpoint.
  */
 export interface ProjectResponse {

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -10,91 +10,50 @@ import {
   filesToProjTitle,
 } from "../../../../apis/azul/hca-dcp/common/transformers";
 
-/* eslint-disable sonarjs/no-duplicate-string -- ignoring duplicate strings here*/
 export const buildFileName = (
   file: FilesResponse
-): React.ComponentProps<typeof C.Text> => {
-  if (!file.files?.[0]) {
-    return {};
-  }
-
+): React.ComponentProps<typeof C.Cell> => {
   return {
-    children: filesToFileName(file),
-    customColor: "ink",
-    variant: "text-body-400",
+    value: filesToFileName(file),
   };
 };
 
 export const buildFileFormat = (
   file: FilesResponse
-): React.ComponentProps<typeof C.Text> => {
-  if (!file.files?.[0]) {
-    return {};
-  }
-
+): React.ComponentProps<typeof C.Cell> => {
   return {
-    children: filesToFileFormat(file),
-    customColor: "ink",
-    variant: "text-body-400",
+    value: filesToFileFormat(file),
   };
 };
 
 export const buildProjTitle = (
   file: FilesResponse
-): React.ComponentProps<typeof C.Text> => {
-  if (!file.projects?.[0]) {
-    return {};
-  }
-
+): React.ComponentProps<typeof C.Cell> => {
   return {
-    children: filesToProjTitle(file),
-    customColor: "ink",
-    variant: "text-body-400",
+    value: filesToProjTitle(file),
   };
 };
 
 export const buildFileSize = (
   file: FilesResponse
-): React.ComponentProps<typeof C.Text> => {
-  if (!file.files?.[0]) {
-    return {};
-  }
-
+): React.ComponentProps<typeof C.Cell> => {
   return {
-    children: filesToFileSize(file),
-    customColor: "ink",
-    variant: "text-body-400",
+    value: filesToFileSize(file),
   };
 };
 
 export const buildContentDesc = (
   file: FilesResponse
-): React.ComponentProps<typeof C.Text> => {
-  if (!file.files?.[0]) {
-    return {};
-  }
-
+): React.ComponentProps<typeof C.Cell> => {
   return {
-    children: filesToContentDesc(file),
-    customColor: "ink",
-    variant: "text-body-400",
+    value: filesToContentDesc(file),
   };
 };
+
 export const buildCellCount = (
   file: FilesResponse
-): React.ComponentProps<typeof C.Text> => {
-  if (!file.projects?.[0].estimatedCellCount) {
-    return {
-      children: 0,
-      customColor: "ink",
-      variant: "text-body-400",
-    };
-  }
-
+): React.ComponentProps<typeof C.Cell> => {
   return {
-    children: filesToCellCount(file),
-    customColor: "ink",
-    variant: "text-body-400",
+    value: filesToCellCount(file),
   };
 };
-/* eslint-enable sonarjs/no-duplicate-string -- ignoring duplicate strings here*/

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -1,12 +1,17 @@
-import { concatStrings } from "app/utils/string";
-import { FilesResponse } from "app/models/responses";
-import * as C from "../../../app/components";
-import { humanFileSize } from "app/utils/fileSize";
+import { FilesResponse } from "../../../../apis/azul/hca-dcp/common/entities";
+import * as C from "../../../../components";
 
-const formatter = Intl.NumberFormat("en", { notation: "compact" });
+import {
+  filesToCellCount,
+  filesToContentDesc,
+  filesToFileFormat,
+  filesToFileName,
+  filesToFileSize,
+  filesToProjTitle,
+} from "../../../../apis/azul/hca-dcp/common/transformers";
 
 /* eslint-disable sonarjs/no-duplicate-string -- ignoring duplicate strings here*/
-export const filesToFileNameColumn = (
+export const buildFileName = (
   file: FilesResponse
 ): React.ComponentProps<typeof C.Text> => {
   if (!file.files?.[0]) {
@@ -14,13 +19,13 @@ export const filesToFileNameColumn = (
   }
 
   return {
-    children: file.files[0].name,
+    children: filesToFileName(file),
     customColor: "ink",
     variant: "text-body-400",
   };
 };
 
-export const filesToFileFormatColumn = (
+export const buildFileFormat = (
   file: FilesResponse
 ): React.ComponentProps<typeof C.Text> => {
   if (!file.files?.[0]) {
@@ -28,13 +33,13 @@ export const filesToFileFormatColumn = (
   }
 
   return {
-    children: file.files[0].format,
+    children: filesToFileFormat(file),
     customColor: "ink",
     variant: "text-body-400",
   };
 };
 
-export const filesToProjTitleColumn = (
+export const buildProjTitle = (
   file: FilesResponse
 ): React.ComponentProps<typeof C.Text> => {
   if (!file.projects?.[0]) {
@@ -42,13 +47,13 @@ export const filesToProjTitleColumn = (
   }
 
   return {
-    children: concatStrings(file.projects[0].projectTitle),
+    children: filesToProjTitle(file),
     customColor: "ink",
     variant: "text-body-400",
   };
 };
 
-export const filesToFileSizeColumn = (
+export const buildFileSize = (
   file: FilesResponse
 ): React.ComponentProps<typeof C.Text> => {
   if (!file.files?.[0]) {
@@ -56,13 +61,13 @@ export const filesToFileSizeColumn = (
   }
 
   return {
-    children: humanFileSize(file.files[0].size),
+    children: filesToFileSize(file),
     customColor: "ink",
     variant: "text-body-400",
   };
 };
 
-export const filesToContentDescColumn = (
+export const buildContentDesc = (
   file: FilesResponse
 ): React.ComponentProps<typeof C.Text> => {
   if (!file.files?.[0]) {
@@ -70,13 +75,12 @@ export const filesToContentDescColumn = (
   }
 
   return {
-    children: concatStrings(file.files[0].contentDescription),
+    children: filesToContentDesc(file),
     customColor: "ink",
     variant: "text-body-400",
   };
 };
-
-export const filesToCellCountColumn = (
+export const buildCellCount = (
   file: FilesResponse
 ): React.ComponentProps<typeof C.Text> => {
   if (!file.projects?.[0].estimatedCellCount) {
@@ -88,9 +92,9 @@ export const filesToCellCountColumn = (
   }
 
   return {
-    children: formatter.format(file.projects[0].estimatedCellCount),
+    children: filesToCellCount(file),
     customColor: "ink",
     variant: "text-body-400",
   };
 };
-/* eslint-enable sonarjs/no-duplicate-string -- watching for duplicate strings here */
+/* eslint-enable sonarjs/no-duplicate-string -- ignoring duplicate strings here*/

--- a/explorer/site-config/hca-dcp/dev/config.ts
+++ b/explorer/site-config/hca-dcp/dev/config.ts
@@ -7,7 +7,7 @@ import { Logo } from "../../../app/components/Layout/common/entities";
 import { summary } from "./index/summary";
 
 // Entities config
-import { filesEntity } from "./filesEntity";
+import { filesEntityConfig } from "./index/filesEntityConfig";
 import { projectsEntity } from "./projectsEntity";
 import { samplesEntity } from "./samplesEntity";
 
@@ -136,7 +136,7 @@ const config: SiteConfig = {
     },
     url: "https://service.dev.singlecell.gi.ucsc.edu/",
   },
-  entities: [projectsEntity, samplesEntity, filesEntity],
+  entities: [projectsEntity, samplesEntity, filesEntityConfig],
   entityTitle: "Explore Data: DCP 2.0 Data View",
   layout: {
     footer: {

--- a/explorer/site-config/hca-dcp/dev/index/filesEntityConfig.ts
+++ b/explorer/site-config/hca-dcp/dev/index/filesEntityConfig.ts
@@ -1,17 +1,24 @@
-import * as ViewBuilder from "./fileTransformer";
-import { buildDevStage } from "./projectViewModelBuilder";
-import * as Components from "../../../app/components";
+import { buildDevStage } from "../projectViewModelBuilder";
+import * as Components from "../../../../app/components";
 import {
   ComponentConfig,
   EntityConfig,
   ListConfig,
-} from "../../../app/config/common/entities";
-import { FilesResponse } from "app/models/responses";
+} from "../../../../app/config/common/entities";
+import { FilesResponse } from "../../../../app/apis/azul/hca-dcp/common/entities";
+import {
+  buildCellCount,
+  buildContentDesc,
+  buildFileFormat,
+  buildFileName,
+  buildFileSize,
+  buildProjTitle,
+} from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
 
 /**
  * Entity config object responsible to config anything related to the /explore/files route.
  */
-export const filesEntity: EntityConfig<FilesResponse> = {
+export const filesEntityConfig: EntityConfig<FilesResponse> = {
   apiPath: "index/files",
   detail: {
     tabs: [],
@@ -23,7 +30,7 @@ export const filesEntity: EntityConfig<FilesResponse> = {
       {
         componentConfig: {
           component: Components.Text,
-          viewBuilder: ViewBuilder.filesToFileNameColumn,
+          viewBuilder: buildFileName,
         } as ComponentConfig<typeof Components.Text>,
         header: "File Name",
         sort: {
@@ -35,7 +42,7 @@ export const filesEntity: EntityConfig<FilesResponse> = {
       {
         componentConfig: {
           component: Components.Text,
-          viewBuilder: ViewBuilder.filesToFileFormatColumn,
+          viewBuilder: buildFileFormat,
         } as ComponentConfig<typeof Components.Text>,
         header: "File Format",
         sort: {
@@ -46,7 +53,7 @@ export const filesEntity: EntityConfig<FilesResponse> = {
       {
         componentConfig: {
           component: Components.Text,
-          viewBuilder: ViewBuilder.filesToFileSizeColumn,
+          viewBuilder: buildFileSize,
         } as ComponentConfig<typeof Components.Text>,
         header: "File Size",
         sort: {
@@ -57,7 +64,7 @@ export const filesEntity: EntityConfig<FilesResponse> = {
       {
         componentConfig: {
           component: Components.Text,
-          viewBuilder: ViewBuilder.filesToContentDescColumn,
+          viewBuilder: buildContentDesc,
         } as ComponentConfig<typeof Components.Text>,
         header: "Content Description",
         sort: {
@@ -68,7 +75,7 @@ export const filesEntity: EntityConfig<FilesResponse> = {
       {
         componentConfig: {
           component: Components.Text,
-          viewBuilder: ViewBuilder.filesToProjTitleColumn,
+          viewBuilder: buildProjTitle,
         } as ComponentConfig<typeof Components.Text>,
         header: "Project Title",
         sort: {
@@ -79,7 +86,7 @@ export const filesEntity: EntityConfig<FilesResponse> = {
       {
         componentConfig: {
           component: Components.Text,
-          viewBuilder: ViewBuilder.filesToCellCountColumn,
+          viewBuilder: buildCellCount,
         } as ComponentConfig<typeof Components.Text>,
         header: "Cell Count Estimate",
         sort: {

--- a/explorer/site-config/hca-dcp/dev/index/filesEntityConfig.ts
+++ b/explorer/site-config/hca-dcp/dev/index/filesEntityConfig.ts
@@ -29,9 +29,9 @@ export const filesEntityConfig: EntityConfig<FilesResponse> = {
     columns: [
       {
         componentConfig: {
-          component: Components.Text,
+          component: Components.Cell,
           viewBuilder: buildFileName,
-        } as ComponentConfig<typeof Components.Text>,
+        } as ComponentConfig<typeof Components.Cell>,
         header: "File Name",
         sort: {
           default: true,
@@ -41,9 +41,9 @@ export const filesEntityConfig: EntityConfig<FilesResponse> = {
       },
       {
         componentConfig: {
-          component: Components.Text,
+          component: Components.Cell,
           viewBuilder: buildFileFormat,
-        } as ComponentConfig<typeof Components.Text>,
+        } as ComponentConfig<typeof Components.Cell>,
         header: "File Format",
         sort: {
           sortKey: "fileFormat",
@@ -52,9 +52,9 @@ export const filesEntityConfig: EntityConfig<FilesResponse> = {
       },
       {
         componentConfig: {
-          component: Components.Text,
+          component: Components.Cell,
           viewBuilder: buildFileSize,
-        } as ComponentConfig<typeof Components.Text>,
+        } as ComponentConfig<typeof Components.Cell>,
         header: "File Size",
         sort: {
           sortKey: "fileSize",
@@ -63,9 +63,9 @@ export const filesEntityConfig: EntityConfig<FilesResponse> = {
       },
       {
         componentConfig: {
-          component: Components.Text,
+          component: Components.Cell,
           viewBuilder: buildContentDesc,
-        } as ComponentConfig<typeof Components.Text>,
+        } as ComponentConfig<typeof Components.Cell>,
         header: "Content Description",
         sort: {
           sortKey: "contentDescription",
@@ -74,9 +74,9 @@ export const filesEntityConfig: EntityConfig<FilesResponse> = {
       },
       {
         componentConfig: {
-          component: Components.Text,
+          component: Components.Cell,
           viewBuilder: buildProjTitle,
-        } as ComponentConfig<typeof Components.Text>,
+        } as ComponentConfig<typeof Components.Cell>,
         header: "Project Title",
         sort: {
           sortKey: "projectTitle",
@@ -85,9 +85,9 @@ export const filesEntityConfig: EntityConfig<FilesResponse> = {
       },
       {
         componentConfig: {
-          component: Components.Text,
+          component: Components.Cell,
           viewBuilder: buildCellCount,
-        } as ComponentConfig<typeof Components.Text>,
+        } as ComponentConfig<typeof Components.Cell>,
         header: "Cell Count Estimate",
         sort: {
           sortKey: "cellCount",


### PR DESCRIPTION
### Ticket
Closes #401.

### Reviewers
@MillenniumFalconMechanic 

### Changes
- Converted file entity related viewbuilders, transformers, response models, and entity models to match Config Guide
- Converted file entity viewbuilders to output `Cell` components instead of `Text` components, and updated entity config to match

### Definition of Done (from ticket)

- Files entity config is updated to match spec.
- hca-dcp-specific view builders file created.
- hca-dcp-specific transformers file created (with the existing fileTransfomer.ts removed).

### Known Issues
- Was silly and tagged commits with the wrong number please lmk if there's anything I can do to correct
