### PR TITLE
AzulFileDownload component + adding component to hca files. #403

### DIFF
--- a/explorer/app/apis/azul/hca-dcp/common/entities.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/entities.ts
@@ -7,6 +7,7 @@ export interface FilesResponse {
     format: string;
     name: string;
     size: number;
+    url: string;
     uuid: string;
   }[];
   projects: {

--- a/explorer/app/apis/azul/hca-dcp/common/transformers.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/transformers.ts
@@ -8,6 +8,9 @@ export const filesToFileName = (file: FilesResponse): string =>
 export const filesToFileFormat = (file: FilesResponse): string =>
   file.files[0].format ?? "";
 
+export const filesToFileUrl = (file: FilesResponse): string =>
+  file.files[0].url ?? "";
+
 export const filesToProjTitle = (file: FilesResponse): string =>
   concatStrings(file.projects[0].projectTitle) ?? "";
 

--- a/explorer/app/components/AzulFileDownload/azulFileDownload.stories.tsx
+++ b/explorer/app/components/AzulFileDownload/azulFileDownload.stories.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { AzulFileDownload } from "./azulFileDownload";
+
+export default {
+  component: AzulFileDownload,
+  title: "Components/AzulFileDownload",
+} as ComponentMeta<typeof AzulFileDownload>;
+
+const Template: ComponentStory<typeof AzulFileDownload> = (args) => (
+  <AzulFileDownload {...args} />
+);
+
+export const Primary = Template.bind({});
+Primary.args = {
+  url: "https://google.com",
+};

--- a/explorer/app/components/AzulFileDownload/azulFileDownload.tsx
+++ b/explorer/app/components/AzulFileDownload/azulFileDownload.tsx
@@ -1,0 +1,20 @@
+// Core dependencies
+import React from "react";
+import DownloadIcon from "@mui/icons-material/Download";
+
+// App dependencies
+import { IconButton } from "../common/IconButton/iconButton";
+
+interface AzulFileDownloadProps {
+  url: string;
+}
+
+export const AzulFileDownload = ({
+  url,
+}: AzulFileDownloadProps): JSX.Element => {
+  const handleClick = (): void => {
+    console.log(url);
+  };
+
+  return <IconButton Icon={DownloadIcon} onClick={handleClick} />;
+};

--- a/explorer/app/components/index.tsx
+++ b/explorer/app/components/index.tsx
@@ -28,3 +28,4 @@ export { Links } from "./Links/Links";
 export { Stack } from "./common/Stack/Stack";
 export { Tooltip } from "./Tooltip/tooltip";
 export { ValueInline } from "./ValueInline/valueInline";
+export { AzulFileDownload } from "./AzulFileDownload/azulFileDownload";

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -7,6 +7,7 @@ import {
   filesToFileFormat,
   filesToFileName,
   filesToFileSize,
+  filesToFileUrl,
   filesToProjTitle,
 } from "../../../../apis/azul/hca-dcp/common/transformers";
 
@@ -15,6 +16,14 @@ export const buildFileName = (
 ): React.ComponentProps<typeof C.Cell> => {
   return {
     value: filesToFileName(file),
+  };
+};
+
+export const buildFileDownload = (
+  file: FilesResponse
+): React.ComponentProps<typeof C.AzulFileDownload> => {
+  return {
+    url: filesToFileUrl(file),
   };
 };
 

--- a/explorer/site-config/hca-dcp/dev/index/filesEntityConfig.ts
+++ b/explorer/site-config/hca-dcp/dev/index/filesEntityConfig.ts
@@ -13,6 +13,7 @@ import {
   buildFileName,
   buildFileSize,
   buildProjTitle,
+  buildFileDownload,
 } from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
 
 /**
@@ -27,6 +28,14 @@ export const filesEntityConfig: EntityConfig<FilesResponse> = {
   label: "Files",
   list: {
     columns: [
+      {
+        componentConfig: {
+          component: Components.AzulFileDownload,
+          viewBuilder: buildFileDownload,
+        } as ComponentConfig<typeof Components.AzulFileDownload>,
+        header: " ",
+        width: { max: "1fr", min: "50px" },
+      },
       {
         componentConfig: {
           component: Components.Cell,


### PR DESCRIPTION
### Ticket
Closes #403 

### Reviewers
@.

### Changes
- Creating AzulFileDownload component
- Adding download component to HCA Files

### Definition of Done (from ticket)
- AnVIL files tab displays a "Download" button in the first cell of each row.
- On click of "Download", the file url value is console.log'ed.

### QA steps (optional)

### Known Issues
There's an issue with table creator if you try to make a table with an empty header.
