### PR TITLE
Separated inner & aggregate responses for FilesEntity in hca-dcp #408

### DIFF
--- a/explorer/app/apis/azul/hca-dcp/common/aggregatedEntities.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/aggregatedEntities.ts
@@ -1,0 +1,8 @@
+export interface AggregateProject {
+  estimatedCellCount?: number;
+  projectTitle: string[];
+}
+
+export interface AggregateProjectResponse {
+  projects: AggregateProject[];
+}

--- a/explorer/app/apis/azul/hca-dcp/common/aggregatedEntities.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/aggregatedEntities.ts
@@ -1,8 +1,8 @@
-export interface AggregateProject {
+export interface AggregatedProject {
   estimatedCellCount?: number;
   projectTitle: string[];
 }
 
-export interface AggregateProjectResponse {
-  projects: AggregateProject[];
+export interface AggregatedProjectResponse {
+  projects: AggregatedProject[];
 }

--- a/explorer/app/apis/azul/hca-dcp/common/entities.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/entities.ts
@@ -1,7 +1,6 @@
 /**
  * Model of response returned from /index/files API endpoint.
  */
-
 export interface FilesEntity {
   contentDescription: string[];
   format: string;

--- a/explorer/app/apis/azul/hca-dcp/common/entities.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/entities.ts
@@ -1,17 +1,16 @@
 /**
  * Model of response returned from /index/files API endpoint.
  */
-export interface FilesResponse {
-  files: {
-    contentDescription: string[];
-    format: string;
-    name: string;
-    size: number;
-    url: string;
-    uuid: string;
-  }[];
-  projects: {
-    estimatedCellCount?: number;
-    projectTitle: string[];
-  }[];
+
+export interface FilesEntity {
+  contentDescription: string[];
+  format: string;
+  name: string;
+  size: number;
+  url: string;
+  uuid: string;
+}
+
+export interface FilesEntityResponse {
+  files: FilesEntity[];
 }

--- a/explorer/app/apis/azul/hca-dcp/common/responses.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/responses.ts
@@ -1,0 +1,7 @@
+import { AzulHit } from "../../common/entities";
+import { FilesEntityResponse } from "./entities";
+import { AggregateProjectResponse } from "./aggregatedEntities";
+
+export type FilesResponse = AzulHit &
+  FilesEntityResponse &
+  AggregateProjectResponse;

--- a/explorer/app/apis/azul/hca-dcp/common/responses.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/responses.ts
@@ -1,7 +1,7 @@
 import { AzulHit } from "../../common/entities";
 import { FilesEntityResponse } from "./entities";
-import { AggregateProjectResponse } from "./aggregatedEntities";
+import { AggregatedProjectResponse } from "./aggregatedEntities";
 
 export type FilesResponse = AzulHit &
   FilesEntityResponse &
-  AggregateProjectResponse;
+  AggregatedProjectResponse;

--- a/explorer/app/apis/azul/hca-dcp/common/transformers.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/transformers.ts
@@ -1,6 +1,6 @@
-import { FilesResponse } from "./entities";
 import { concatStrings } from "../../../../utils/string";
 import { humanFileSize } from "../../../../utils/fileSize";
+import { FilesResponse } from "./responses";
 
 export const filesToFileName = (file: FilesResponse): string =>
   file.files[0].name ?? "";

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -1,4 +1,3 @@
-import { FilesResponse } from "../../../../apis/azul/hca-dcp/common/entities";
 import * as C from "../../../../components";
 
 import {
@@ -10,6 +9,7 @@ import {
   filesToFileUrl,
   filesToProjTitle,
 } from "../../../../apis/azul/hca-dcp/common/transformers";
+import { FilesResponse } from "../../../../apis/azul/hca-dcp/common/responses";
 
 export const buildFileName = (
   file: FilesResponse

--- a/explorer/site-config/hca-dcp/dev/index/filesEntityConfig.ts
+++ b/explorer/site-config/hca-dcp/dev/index/filesEntityConfig.ts
@@ -5,7 +5,7 @@ import {
   EntityConfig,
   ListConfig,
 } from "../../../../app/config/common/entities";
-import { FilesResponse } from "../../../../app/apis/azul/hca-dcp/common/entities";
+import { FilesResponse } from "../../../../app/apis/azul/hca-dcp/common/responses";
 import {
   buildCellCount,
   buildContentDesc,


### PR DESCRIPTION
### Ticket
Closes #408 .

### Reviewers
@MillenniumFalconMechanic .

### Changes
- Created files for responess, entities, and aggregatedEntities, and separated out definitions to match the anvil implementation for hca-dcp FilesEntity
- Updated transformers and entityConfig to match

