### PR TITLE
Refactored FilesResponse into entities, aggregated entities and respo…

### DIFF
--- a/explorer/app/apis/azul/hca-dcp/common/aggregatedEntities.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/aggregatedEntities.ts
@@ -3,6 +3,23 @@ export interface AggregatedProject {
   projectTitle: string[];
 }
 
-export interface AggregatedProjectResponse {
+export interface AggregatedProjectsResponse {
   projects: AggregatedProject[];
+}
+
+export interface AggregatedDonorOrganisms {
+  disease: string[];
+  genusSpecies: string[];
+}
+
+export interface AggregatedDonorOrganismsResponse {
+  donorOrganisms: AggregatedDonorOrganisms[];
+}
+
+export interface AggregatedProtocols {
+  libraryConstructionApproach: string[];
+}
+
+export interface AggregatedProtocolsResponse {
+  protocols: AggregatedProtocols[];
 }

--- a/explorer/app/apis/azul/hca-dcp/common/entities.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/entities.ts
@@ -1,6 +1,3 @@
-/**
- * Model of response returned from /index/files API endpoint.
- */
 export interface FilesEntity {
   contentDescription: string[];
   format: string;
@@ -14,24 +11,12 @@ export interface FilesEntityResponse {
   files: FilesEntity[];
 }
 
-/**
- * Model of response returned from /index/samples API endpoint.
- */
-export interface SamplesResponse {
-  donorOrganisms: {
-    disease: string[];
-    genusSpecies: string[];
-  }[];
-  projects: {
-    estimatedCellCount?: number;
-    projectTitle: string[];
-  }[];
-  protocols: {
-    libraryConstructionApproach: string[];
-  }[];
-  samples: {
-    id: string;
-    organ: string;
-    sampleEntityType: string;
-  }[];
+export interface SamplesEntity {
+  id: string;
+  organ: string;
+  sampleEntityType: string;
+}
+
+export interface SamplesEntityResponse {
+  samples: SamplesEntity[];
 }

--- a/explorer/app/apis/azul/hca-dcp/common/responses.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/responses.ts
@@ -1,7 +1,23 @@
 import { AzulHit } from "../../common/entities";
-import { FilesEntityResponse } from "./entities";
-import { AggregatedProjectResponse } from "./aggregatedEntities";
+import { FilesEntityResponse, SamplesEntityResponse } from "./entities";
+import {
+  AggregatedDonorOrganismsResponse,
+  AggregatedProjectsResponse,
+  AggregatedProtocolsResponse,
+} from "./aggregatedEntities";
 
+/**
+ * Model of response returned from /index/files API endpoint.
+ */
 export type FilesResponse = AzulHit &
   FilesEntityResponse &
-  AggregatedProjectResponse;
+  AggregatedProjectsResponse;
+
+/**
+ * Model of response returned from /index/samples API endpoint.
+ */
+export type SamplesResponse = AzulHit &
+  SamplesEntityResponse &
+  AggregatedDonorOrganismsResponse &
+  AggregatedProjectsResponse &
+  AggregatedProtocolsResponse;

--- a/explorer/app/apis/azul/hca-dcp/common/transformers.ts
+++ b/explorer/app/apis/azul/hca-dcp/common/transformers.ts
@@ -1,7 +1,6 @@
 import { concatStrings } from "../../../../utils/string";
 import { humanFileSize } from "../../../../utils/fileSize";
-import { FilesResponse } from "./responses";
-import { SamplesResponse } from "./entities";
+import { FilesResponse, SamplesResponse } from "./responses";
 
 //FilesResponse
 

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -2,9 +2,8 @@
 import React from "react";
 
 // App dependencies
-import { FilesResponse } from "../../../../apis/azul/hca-dcp/common/responses";
+import { FilesResponse, SamplesResponse } from "../../../../apis/azul/hca-dcp/common/responses";
 import * as Transformers from "../../../../apis/azul/hca-dcp/common/transformers";
-import { SamplesResponse } from "../../../../apis/azul/hca-dcp/common/entities";
 import * as C from "../../../../components";
 
 /**

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -2,7 +2,10 @@
 import React from "react";
 
 // App dependencies
-import { FilesResponse, SamplesResponse } from "../../../../apis/azul/hca-dcp/common/responses";
+import {
+  FilesResponse,
+  SamplesResponse,
+} from "../../../../apis/azul/hca-dcp/common/responses";
 import * as Transformers from "../../../../apis/azul/hca-dcp/common/transformers";
 import * as C from "../../../../components";
 

--- a/explorer/site-config/hca-dcp/dev/index/samplesEntityConfig.ts
+++ b/explorer/site-config/hca-dcp/dev/index/samplesEntityConfig.ts
@@ -5,7 +5,6 @@ import {
   ListConfig,
 } from "../../../../app/config/common/entities";
 import { buildDevStage } from "../projectViewModelBuilder";
-import { SamplesResponse } from "../../../../app/apis/azul/hca-dcp/common/entities";
 import {
   samplesBuildAnatomicalEntity,
   samplesBuildCellCount,
@@ -16,6 +15,7 @@ import {
   samplesBuildSampleType,
   samplesBuildSpecies,
 } from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
+import { SamplesResponse } from "../../../../app/apis/azul/hca-dcp/common/responses";
 
 /**
  * Entity config object responsible to config anything related to the /explore/samples route.


### PR DESCRIPTION
…nse models #431

### Ticket
Closes #431 .

### Reviewers
@MillenniumFalconMechanic .

### Changes
- Separated `SamplesResponse` into a response, entity, and aggregate response

### Definition of Done (from ticket)
- SamplesResponse is a "mix" of AzulHit, the core file entity response as well as an aggregated samples response and an aggregated projects response.
