### PR TITLE
Add data download policy to AnVIL choose export method page. #450.

### DIFF
--- a/explorer/app/viewModelBuilders/azul/anvil/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/anvil/common/viewModelBuilders.ts
@@ -176,6 +176,20 @@ export const buildDataModality = (
 };
 
 /**
+ * Build props for TitledText component for the display of the data release policy.
+ * @returns model to be used as props for the TitledText component.
+ */
+export const buildDataReleasePolicy = (): React.ComponentProps<
+  typeof C.TitledText
+> => {
+  return {
+    text: [
+      "Downloaded data is governed by the AnVIL Data Release Policy and licensed under the Creative Commons Attribution 4.0 International License (CC BY 4.0). For more information please see our Data Use Agreement.",
+    ],
+  };
+};
+
+/**
  * Build dataset name Cell component from the given index/datasets response.
  * @param response - Response model return from index/datasets API.
  * @returns model to be used as props for the dataset name cell.

--- a/explorer/site-config/anvil/dev/export/export.ts
+++ b/explorer/site-config/anvil/dev/export/export.ts
@@ -14,7 +14,12 @@ export const exportConfig: BackPageConfig = {
         } as ComponentConfig<typeof C.ExportMethod>,
       ],
       route: "/export",
-      sideColumn: [],
+      sideColumn: [
+        {
+          component: C.TitledText,
+          viewBuilder: T.buildDataReleasePolicy,
+        } as ComponentConfig<typeof C.TitledText>,
+      ],
     },
   ],
   top: [


### PR DESCRIPTION
### Ticket
Closes #450 .

### Reviewers
@MillenniumFalconMechanic .

### Changes
- Added AnVIL data release policy to choose export method page.

### Definition of Done (from ticket)
- AnVIL data release policy is added to the choose export method page.

### Known Issues
- The export method page styles will be resolved with tix #417, #400 and #415. 