### PR TITLE
Configure HCA choose export method page. #451.

### DIFF
--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -1,8 +1,40 @@
+// Core dependencies
+import React from "react";
+
+// App dependencies
+import { FilesResponse } from "../../../../apis/azul/hca-dcp/common/responses";
+import * as Transformers from "../../../../apis/azul/hca-dcp/common/transformers";
+import { SamplesResponse } from "../../../../apis/azul/hca-dcp/common/entities";
 import * as C from "../../../../components";
 
-import * as Transformers from "../../../../apis/azul/hca-dcp/common/transformers";
-import { FilesResponse } from "../../../../apis/azul/hca-dcp/common/responses";
-import { SamplesResponse } from "../../../../apis/azul/hca-dcp/common/entities";
+/**
+ * Build props for TitledText component for the display of the data release policy section.
+ * @returns model to be used as props for the TitledText component.
+ */
+export const buildDataReleasePolicy = (): React.ComponentProps<
+  typeof C.TitledText
+> => {
+  return {
+    text: [
+      "Downloaded data is governed by the HCA Data Release Policy and licensed under the Creative Commons Attribution 4.0 International License (CC BY 4.0). For more information please see our Data Use Agreement.",
+    ],
+  };
+};
+
+/**
+ * Build props for ExportMethod component for display of the export to terra metadata section.
+ * @returns model to be used as props for the ExportMethod component.
+ */
+export const buildExportToTerraMetadata = (): React.ComponentProps<
+  typeof C.ExportMethod
+> => ({
+  buttonLabel: "Analyze in Terra",
+  description:
+    "Terra is a biomedical research platform to analyze data using workflows, Jupyter Notebooks, RStudio, and Galaxy.",
+  disabled: false,
+  route: "/export",
+  title: "Export Study Data and Metadata to Terra Workspace",
+});
 
 // Files view builders
 

--- a/explorer/site-config/hca-dcp/dev/config.ts
+++ b/explorer/site-config/hca-dcp/dev/config.ts
@@ -13,6 +13,9 @@ import { filesEntityConfig } from "./index/filesEntityConfig";
 import { projectsEntity } from "./projectsEntity";
 import { samplesEntityConfig } from "./index/samplesEntityConfig";
 
+// Export config
+import { exportConfig } from "./export/export";
+
 // Images
 import logoHca from "images/logoHca.png";
 import logoHumanCellAtlas from "images/logoHumanCellAtlas.png";
@@ -140,6 +143,7 @@ const config: SiteConfig = {
   },
   entities: [projectsEntity, samplesEntityConfig, filesEntityConfig],
   entityTitle: "Explore Data: DCP 2.0 Data View",
+  export: exportConfig,
   layout: {
     footer: {
       feedbackForm: false, // TODO feedback form

--- a/explorer/site-config/hca-dcp/dev/export/export.ts
+++ b/explorer/site-config/hca-dcp/dev/export/export.ts
@@ -1,0 +1,37 @@
+// App dependencies
+import * as C from "app/components";
+import { BackPageConfig, ComponentConfig } from "app/config/common/entities";
+import * as T from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
+
+export const exportConfig: BackPageConfig = {
+  tabs: [
+    {
+      label: "Choose Export Method",
+      mainColumn: [
+        {
+          component: C.ExportMethod,
+          viewBuilder: T.buildExportToTerraMetadata,
+        } as ComponentConfig<typeof C.ExportMethod>,
+      ],
+      route: "/export",
+      sideColumn: [
+        {
+          component: C.TitledText,
+          viewBuilder: T.buildDataReleasePolicy,
+        } as ComponentConfig<typeof C.TitledText>,
+      ],
+    },
+  ],
+  top: [
+    {
+      component: C.ProjectHero,
+      props: {
+        breadcrumbs: [
+          { path: "/projects", text: "Projects" },
+          { path: "export", text: "Export" },
+        ],
+        title: "Choose Export Method",
+      },
+    } as ComponentConfig<typeof C.ProjectHero>,
+  ],
+};


### PR DESCRIPTION
### Ticket
Closes #451.

### Reviewers
@MillenniumFalconMechanic.

### Changes
- Configured HCA choose to export method page (including corresponding data release policy).

### Definition of Done (from ticket)
Clicking on "Export" button in HCA (and LungMAP) displays a configured choose export method page, listing the export to Terra option.

### Known Issues
- Choose to export method styles to be resolved with tix #415, #417 and #400. 