### PR TITLE
Revert BackPage to be specific to entity detail. #456.

### DIFF
--- a/explorer/app/components/Detail/detail.stories.tsx
+++ b/explorer/app/components/Detail/detail.stories.tsx
@@ -1,0 +1,63 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+import { ProjectCitation } from "../Project/components/Citation/citation.stories";
+import { ProjectCollaboratingOrganizations } from "../Project/components/CollaboratingOrganizations/collaboratingOrganizations.stories";
+import { ProjectContacts } from "../Project/components/Contacts/contacts.stories";
+import { ProjectContributors } from "../Project/components/Contributors/contributors.stories";
+import { ProjectDataCurators } from "../Project/components/DataCurators/dataCurators.stories";
+import { ProjectDataReleasePolicy } from "../Project/components/DataReleasePolicy/dataReleasePolicy.stories";
+import { ProjectDescription } from "../Project/components/Description/description.stories";
+import { ProjectDetails } from "../Project/components/Details/details.stories";
+import { ProjectHero } from "../Project/components/Hero/hero.stories";
+import { ProjectPublications } from "../Project/components/Publications/publications.stories";
+import { ProjectSupplementaryLinks } from "../Project/components/SupplementaryLinks/supplementaryLinks.stories";
+import { Detail } from "./detail";
+
+export default {
+  argTypes: {
+    Tabs: { table: { disable: true } },
+    mainColumn: { table: { disable: true } },
+    sideColumn: { table: { disable: true } },
+    top: { table: { disable: true } },
+  },
+  component: Detail,
+  parameters: {
+    layout: "fullscreen",
+  },
+  title: "Views/Detail",
+} as ComponentMeta<typeof Detail>;
+
+const Template: ComponentStory<typeof Detail> = (args) => <Detail {...args} />;
+
+export const HCAProjectDetail = Template.bind({});
+HCAProjectDetail.args = {
+  mainColumn: (
+    <>
+      <ProjectDescription
+        projectDescription={
+          ProjectDescription.args?.projectDescription || "None"
+        }
+      />
+      <ProjectContacts {...ProjectContacts.args} />
+      <ProjectPublications {...ProjectPublications.args} />
+      <ProjectContributors {...ProjectContributors.args} />
+      <ProjectCollaboratingOrganizations
+        {...ProjectCollaboratingOrganizations.args}
+      />
+      <ProjectDataCurators {...ProjectDataCurators.args} />
+      <ProjectCitation {...ProjectCitation.args} />
+      <ProjectSupplementaryLinks {...ProjectSupplementaryLinks.args} />
+      <ProjectDataReleasePolicy />
+    </>
+  ),
+  sideColumn: (
+    <>
+      <ProjectDetails {...ProjectDetails.args} />
+    </>
+  ),
+  top: (
+    <>
+      <ProjectHero {...ProjectHero.args} />
+    </>
+  ),
+};

--- a/explorer/app/components/Detail/detail.tsx
+++ b/explorer/app/components/Detail/detail.tsx
@@ -1,0 +1,25 @@
+import React, { ReactNode } from "react";
+import { BackPageView } from "../Layout/components/BackPage/backPageView";
+
+interface Props {
+  mainColumn: ReactNode;
+  sideColumn: ReactNode;
+  Tabs?: ReactNode;
+  top: ReactNode;
+}
+
+export const Detail = ({
+  mainColumn,
+  sideColumn,
+  Tabs,
+  top,
+}: Props): JSX.Element => {
+  return (
+    <BackPageView
+      mainColumn={mainColumn}
+      sideColumn={sideColumn}
+      Tabs={Tabs}
+      top={top}
+    />
+  );
+};

--- a/explorer/app/views/Detail/detail.tsx
+++ b/explorer/app/views/Detail/detail.tsx
@@ -1,5 +1,5 @@
 import { ComponentCreator } from "app/components/ComponentCreator/ComponentCreator";
-import { BackPageView } from "app/components/Layout/components/BackPage/backPageView";
+import { Detail as DetailView } from "app/components/Detail/detail";
 import { useCurrentDetailTab } from "app/hooks/useCurrentDetailTab";
 import { useCurrentEntity } from "app/hooks/useCurrentEntity";
 import { useFetchEntity } from "app/hooks/useFetchEntity";
@@ -27,7 +27,7 @@ function getTabs(entity: EntityConfig): Tab[] {
   }));
 }
 
-export const BackPage = (props: AzulEntityStaticResponse): JSX.Element => {
+export const Detail = (props: AzulEntityStaticResponse): JSX.Element => {
   const { currentTab, route: tabRoute } = useCurrentDetailTab();
   const entity = useCurrentEntity();
   const { isLoading, response } = useFetchEntity(props);
@@ -56,7 +56,7 @@ export const BackPage = (props: AzulEntityStaticResponse): JSX.Element => {
   };
 
   return (
-    <BackPageView
+    <DetailView
       mainColumn={
         <ComponentCreator components={mainColumn} response={response} />
       }

--- a/explorer/pages/[slug]/[...params].tsx
+++ b/explorer/pages/[slug]/[...params].tsx
@@ -7,7 +7,7 @@ import { ParsedUrlQuery } from "querystring";
 import React from "react";
 import { AzulEntityStaticResponse } from "../../app/apis/azul/common/entities";
 import { Page } from "../../app/components/Layout/components/Page/page";
-import { BackPage } from "../../app/views/BackPage/backPage";
+import { Detail } from "../../app/views/Detail/detail";
 
 interface PageUrl extends ParsedUrlQuery {
   params: string[];
@@ -25,7 +25,7 @@ const ProjectPage = ({ slug, ...props }: ProjectPageProps): JSX.Element => {
 
   return (
     <Page entity={entity}>
-      <BackPage {...props} />
+      <Detail {...props} />
     </Page>
   );
 };

--- a/explorer/pages/datasets/[...params].tsx
+++ b/explorer/pages/datasets/[...params].tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Page } from "../../app/components/Layout/components/Page/page";
 import { config } from "../../app/config/config";
 import { getCurrentEntity } from "../../app/hooks/useCurrentEntity";
-import { BackPage } from "../../app/views/BackPage/backPage";
+import { Detail } from "../../app/views/Detail/detail";
 
 /**
  * WIP dataset detail page. TODO revisit - is this configurable?
@@ -21,7 +21,7 @@ const DatasetPage = (props: any): JSX.Element => {
   const entity = getCurrentEntity("datasets", config());
   return (
     <Page entity={entity}>
-      <BackPage {...props} />
+      <Detail {...props} />
     </Page>
   );
 };


### PR DESCRIPTION
### Ticket
Closes #456.

### Reviewers
@MillenniumFalconMechanic.

### Changes
- Refactored `BackPage` component to `Detail`.
- Added new `Detail` component similar to `Index` component `explorer/app/components/Index/index.tsx`.
- Added corresponding SB for new `Detail` component.

### Definition of Done (from ticket)
- BackPage component has been renamed to `Detail` and a new `Detail` component is created similar to `Index` component `explorer/app/components/Index/index.tsx`.