### PR TITLE
Refactor Paper components. #417.

### DIFF
--- a/explorer/app/components/Export/components/ExportMethod/exportMethod.tsx
+++ b/explorer/app/components/Export/components/ExportMethod/exportMethod.tsx
@@ -1,4 +1,4 @@
-import { RoundedPaper } from "app/components/common/Paper/paper.styles";
+import { FluidPaper } from "app/components/common/Paper/paper.styles";
 import {
   Content as SectionContent,
   Section,
@@ -25,7 +25,7 @@ export const ExportMethod = ({
   title,
 }: Props): JSX.Element => {
   return (
-    <RoundedPaper>
+    <FluidPaper>
       <Section>
         <SectionTitle title={title} />
         <SectionContent component="div" variant="text-body-400-2lines">
@@ -37,6 +37,6 @@ export const ExportMethod = ({
           </Link>
         </SectionCallout>
       </Section>
-    </RoundedPaper>
+    </FluidPaper>
   );
 };

--- a/explorer/app/components/Export/components/ExportToTerra/components/ExportToTerraNotStarted/exportToTerraNotStarted.tsx
+++ b/explorer/app/components/Export/components/ExportToTerra/components/ExportToTerraNotStarted/exportToTerraNotStarted.tsx
@@ -1,5 +1,5 @@
 import { ButtonPrimary } from "app/components/common/Button/button.styles";
-import { RoundedPaper } from "app/components/common/Paper/paper.styles";
+import { FluidPaper } from "app/components/common/Paper/paper.styles";
 import {
   Content as SectionText,
   Section,
@@ -20,7 +20,7 @@ interface Props {
 
 export const ExportToTerraNotStarted = ({ run }: Props): JSX.Element => {
   return (
-    <RoundedPaper>
+    <FluidPaper>
       <Section>
         <SectionContent gap={2}>
           <SectionTitle title="Export To Terra" />
@@ -32,6 +32,6 @@ export const ExportToTerraNotStarted = ({ run }: Props): JSX.Element => {
           <ButtonPrimary onClick={run}>Request link</ButtonPrimary>
         </SectionActions>
       </Section>
-    </RoundedPaper>
+    </FluidPaper>
   );
 };

--- a/explorer/app/components/Export/components/ExportToTerra/components/ExportToTerraReady/exportToTerraReady.tsx
+++ b/explorer/app/components/Export/components/ExportToTerra/components/ExportToTerraReady/exportToTerraReady.tsx
@@ -1,5 +1,5 @@
 import { ButtonPrimary } from "app/components/common/Button/button.styles";
-import { RoundedPaper } from "app/components/common/Paper/paper.styles";
+import { FluidPaper } from "app/components/common/Paper/paper.styles";
 import { SectionTitle } from "app/components/Project/components/Section/components/SectionTitle/sectionTitle";
 import {
   Content as SectionText,
@@ -19,7 +19,7 @@ interface Props {
 
 export const ExportToTerraReady = ({ terraUrl }: Props): JSX.Element => {
   return (
-    <RoundedPaper>
+    <FluidPaper>
       <Section>
         <SectionContent gap={2}>
           <SectionTitle title="Your Terra Workspace Link is Ready" />
@@ -39,6 +39,6 @@ export const ExportToTerraReady = ({ terraUrl }: Props): JSX.Element => {
           </Link>
         </SectionActions>
       </Section>
-    </RoundedPaper>
+    </FluidPaper>
   );
 };

--- a/explorer/app/components/NoResults/noResults.styles.ts
+++ b/explorer/app/components/NoResults/noResults.styles.ts
@@ -4,7 +4,6 @@ import { Stack } from "../common/Stack/Stack";
 
 export const Section = styled.div`
   align-items: center;
-  background-color: ${({ theme }) => theme.palette.common.white};
   display: flex;
   flex-direction: column;
   gap: 16px;

--- a/explorer/app/components/Project/components/Section/section.styles.ts
+++ b/explorer/app/components/Project/components/Section/section.styles.ts
@@ -5,7 +5,6 @@ import { BREAKPOINT } from "../../../../hooks/useBreakpointHelper";
 import { SectionTitle as Title } from "./components/SectionTitle/sectionTitle";
 
 export const Section = styled.div`
-  background-color: ${({ theme }) => theme.palette.common.white};
   padding: 20px 16px;
 
   ${({ theme }) => theme.breakpoints.up(BREAKPOINT.TABLET)} {

--- a/explorer/app/components/Project/components/TitledText/titledText.styles.ts
+++ b/explorer/app/components/Project/components/TitledText/titledText.styles.ts
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 import { Typography } from "@mui/material";
-import { SectionContent as Content } from "../Section/section.styles";
+import { Content } from "../Section/section.styles";
 
 export const SectionContent = styled(Content)`
   gap: 0;

--- a/explorer/app/components/Project/components/TitledText/titledText.tsx
+++ b/explorer/app/components/Project/components/TitledText/titledText.tsx
@@ -1,9 +1,7 @@
+import { FluidPaper } from "app/components/common/Paper/paper.styles";
 import React, { ReactNode } from "react";
 import { SectionTitle } from "../Section/components/SectionTitle/sectionTitle";
-import {
-  CollapsableSection as Section,
-  SectionSummary,
-} from "../Section/section.styles";
+import { Section } from "../Section/section.styles";
 import { SectionContent } from "./titledText.styles";
 
 export type Content = ReactNode | ReactNode[] | string[];
@@ -56,17 +54,14 @@ function isContentStringArray(contents: Content): contents is string[] {
 }
 
 export const TitledText = ({ text, title }: Props): JSX.Element => {
-  const Summary = SectionSummary.withComponent("div");
   return (
-    <Section>
-      {title ? (
-        <Summary>
-          <SectionTitle title={title} />
-        </Summary>
-      ) : null}
-      <SectionContent component="div" variant="text-body-400-2lines">
-        {getSectionContent(text)}
-      </SectionContent>
-    </Section>
+    <FluidPaper>
+      <Section>
+        {title && <SectionTitle title={title} />}
+        <SectionContent component="div" variant="text-body-400-2lines">
+          {getSectionContent(text)}
+        </SectionContent>
+      </Section>
+    </FluidPaper>
   );
 };

--- a/explorer/app/components/Table/table.tsx
+++ b/explorer/app/components/Table/table.tsx
@@ -18,7 +18,7 @@ import { useScroll } from "app/hooks/useScroll";
 import React from "react";
 import { Pagination, Sort, SortOrderType } from "../../common/entities";
 import { CheckboxMenu, CheckboxMenuItem } from "../CheckboxMenu/checkboxMenu";
-import { RoundedPaper } from "../common/Paper/paper.styles";
+import { GridPaper, RoundedPaper } from "../common/Paper/paper.styles";
 import { RoundedLoading } from "../Loading/loading.styles";
 import { Pagination as DXPagination } from "./components/Pagination/pagination";
 import { PaginationSummary } from "./components/PaginationSummary/paginationSummary";
@@ -139,83 +139,85 @@ export const Table = <T extends object>({
     <div>
       <RoundedLoading loading={loading || false} />
       <RoundedPaper>
-        {editColumns && (
-          <TableToolbar>
-            <PaginationSummary
-              firstResult={(currentPage - 1) * pageSize + 1}
-              lastResult={pageSize * currentPage}
-              totalResult={totalPage * pageSize}
-            />
-            <CheckboxMenu
-              label="Edit Columns"
-              onItemSelectionChange={editColumns.onVisibleColumnsChange}
-              options={editColumns.options}
-              readOnly={editColumns.readOnlyColumns}
-              selected={editColumns.selectedColumns}
-            />
-          </TableToolbar>
-        )}
-        <TableContainer>
-          <GridTable gridTemplateColumns={gridTemplateColumns}>
-            {getHeaderGroups().map((headerGroup) => (
-              <TableHead key={headerGroup.id}>
-                <TableRow>
-                  {headerGroup.headers.map((header) => (
-                    <TableCell key={header.id}>
-                      <TableSortLabel
-                        active={!!header.column.getIsSorted()}
-                        direction={
-                          !header.column.getIsSorted()
-                            ? "asc"
-                            : (header.column.getIsSorted() as SortOrderType)
-                        }
-                        disabled={!header.column.columnDef.enableSorting}
-                        IconComponent={SouthRoundedIcon}
-                        onClick={(): void =>
-                          handleSortClicked(header.column.columnDef)
-                        }
-                      >
-                        {flexRender(
-                          header.column.columnDef.header,
-                          header.getContext()
-                        )}
-                      </TableSortLabel>
-                    </TableCell>
-                  ))}
-                </TableRow>
-              </TableHead>
-            ))}
-
-            <TableBody>
-              {getRowModel().rows.map((row) => (
-                <TableRow key={row.id}>
-                  {row.getVisibleCells().map((cell) => {
-                    return (
-                      <TableCell key={cell.id}>
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext()
-                        )}
+        <GridPaper>
+          {editColumns && (
+            <TableToolbar>
+              <PaginationSummary
+                firstResult={(currentPage - 1) * pageSize + 1}
+                lastResult={pageSize * currentPage}
+                totalResult={totalPage * pageSize}
+              />
+              <CheckboxMenu
+                label="Edit Columns"
+                onItemSelectionChange={editColumns.onVisibleColumnsChange}
+                options={editColumns.options}
+                readOnly={editColumns.readOnlyColumns}
+                selected={editColumns.selectedColumns}
+              />
+            </TableToolbar>
+          )}
+          <TableContainer>
+            <GridTable gridTemplateColumns={gridTemplateColumns}>
+              {getHeaderGroups().map((headerGroup) => (
+                <TableHead key={headerGroup.id}>
+                  <TableRow>
+                    {headerGroup.headers.map((header) => (
+                      <TableCell key={header.id}>
+                        <TableSortLabel
+                          active={!!header.column.getIsSorted()}
+                          direction={
+                            !header.column.getIsSorted()
+                              ? "asc"
+                              : (header.column.getIsSorted() as SortOrderType)
+                          }
+                          disabled={!header.column.columnDef.enableSorting}
+                          IconComponent={SouthRoundedIcon}
+                          onClick={(): void =>
+                            handleSortClicked(header.column.columnDef)
+                          }
+                        >
+                          {flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
+                        </TableSortLabel>
                       </TableCell>
-                    );
-                  })}
-                </TableRow>
+                    ))}
+                  </TableRow>
+                </TableHead>
               ))}
-            </TableBody>
-          </GridTable>
-        </TableContainer>
-        {!disablePagination && (
-          <DXPagination
-            canNextPage={pagination?.canNextPage ?? !!tableCanNextPage}
-            canPreviousPage={
-              pagination?.canPreviousPage ?? !!tableCanPreviousPage
-            }
-            currentPage={currentPage}
-            onNextPage={handleTableNextPage}
-            onPreviousPage={handleTablePreviousPage}
-            totalPage={totalPage}
-          />
-        )}
+
+              <TableBody>
+                {getRowModel().rows.map((row) => (
+                  <TableRow key={row.id}>
+                    {row.getVisibleCells().map((cell) => {
+                      return (
+                        <TableCell key={cell.id}>
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext()
+                          )}
+                        </TableCell>
+                      );
+                    })}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </GridTable>
+          </TableContainer>
+          {!disablePagination && (
+            <DXPagination
+              canNextPage={pagination?.canNextPage ?? !!tableCanNextPage}
+              canPreviousPage={
+                pagination?.canPreviousPage ?? !!tableCanPreviousPage
+              }
+              currentPage={currentPage}
+              onNextPage={handleTableNextPage}
+              onPreviousPage={handleTablePreviousPage}
+              totalPage={totalPage}
+            />
+          )}
+        </GridPaper>
       </RoundedPaper>
     </div>
   );

--- a/explorer/app/components/common/Paper/paper.styles.ts
+++ b/explorer/app/components/common/Paper/paper.styles.ts
@@ -1,5 +1,5 @@
-// TODO review paper align-self styles with ticket https://github.com/clevercanary/data-browser/issues/417
 import styled from "@emotion/styled";
+import { BREAKPOINT } from "../../../hooks/useBreakpointHelper";
 import { Paper } from "./paper";
 
 /**
@@ -7,6 +7,7 @@ import { Paper } from "./paper";
  * e.g. the entire width of mobile viewports.
  */
 export const FlatPaper = styled(Paper)`
+  align-self: stretch;
   border-left: none;
   border-radius: 0;
   border-right: none;
@@ -15,17 +16,49 @@ export const FlatPaper = styled(Paper)`
 
 /**
  * Rounded paper - typically used when contained within a parent container.
+ * To use RoundedPaper, wrap the styled paper around a single child element e.g. "Section" or "Sections" component. TODO
  */
 export const RoundedPaper = styled(Paper)`
+  align-self: stretch;
   border-radius: 8px;
+`;
 
-  & > :first-of-type {
-    border-top-left-radius: 8px;
-    border-top-right-radius: 8px;
+/* eslint-disable valid-jsdoc -- disable require param */
+/**
+ * Fluid paper - typically used to transition between flat paper (mobile) and rounded paper (tablet or desktop).
+ * To use FluidPaper, wrap the styled paper around a single child element e.g. "Section" or "Sections" component. TODO
+ */
+/* eslint-enable valid-jsdoc -- disable require param */
+export const FluidPaper = styled(RoundedPaper)`
+  ${({ theme }) => theme.breakpoints.down(BREAKPOINT.TABLET)} {
+    border-left: none;
+    border-radius: 0;
+    border-right: none;
+    box-shadow: none;
+  }
+`;
+
+/* eslint-disable valid-jsdoc -- disable require param */
+/**
+ * Grid paper - typically used as a parent (grid) container.
+ * The background color with the grid cap property create the grid "lines" between each grid item.
+ */
+/* eslint-enable valid-jsdoc -- disable require param */
+export const GridPaper = styled.div`
+  background-color: ${({ theme }) => theme.palette.smoke.main};
+  border-radius: inherit; // Inherit parent container border radius.
+  display: grid;
+  gap: 1px;
+
+  // First child inherits top left and right border radius.
+  > *:first-child {
+    border-top-left-radius: inherit;
+    border-top-right-radius: inherit;
   }
 
-  & > :last-of-type {
-    border-bottom-left-radius: 8px;
-    border-bottom-right-radius: 8px;
+  // Last child inherits bottom left and right border radius.
+  > *:last-child {
+    border-bottom-left-radius: inherit;
+    border-bottom-right-radius: inherit;
   }
 `;

--- a/explorer/app/theme/theme.ts
+++ b/explorer/app/theme/theme.ts
@@ -595,13 +595,10 @@ export const getAppTheme = (customTheme?: ThemeOptions): Theme => {
             boxShadow: elevation02,
           },
           panel: {
-            backgroundColor: smoke,
             borderColor: smoke,
             borderStyle: "solid",
             borderWidth: 1,
             boxShadow: elevation01,
-            display: "grid",
-            gap: 1,
           },
           sidebar: {
             backgroundColor: smokeLight,

--- a/explorer/app/views/ExportToTerraPage/sideColumn.tsx
+++ b/explorer/app/views/ExportToTerraPage/sideColumn.tsx
@@ -1,3 +1,4 @@
+// TODO review use of data release policy stories component
 import { ProjectDataReleasePolicy } from "app/components/Project/components/DataReleasePolicy/dataReleasePolicy.stories";
 import React from "react";
 


### PR DESCRIPTION
### Ticket
Closes #417.

### Reviewers
@MillenniumFalconMechanic.

### Changes
- Refactored paper styles.
- Added "FluidPaper" and "GridPaper" styles to handle responsive changes to sections.
- Removed unnecessary and unwanted background colour from `Section` styles.
- Refactored `TitledText` component to generic section styles with `FluidPaper` container. Resolves poor rending of TitledText for mobile.

### Definition of Done (from ticket)
- Both RoundedPaper and FlatPaper components are simplified and without grid styles.
- Added GridPaper to handle gridded layouts.
- Added FluidPaper to handle responsive switch between FlatPaper (mobile) and RoundedPaper (tablet).

### Known Issues
- Project detail page style temporarily broken until ticket #415 and #465 are completed.