### PR TITLE
Fix Loading component. #491.

### DIFF
--- a/explorer/app/components/Export/components/ExportToTerra/exportToTerra.tsx
+++ b/explorer/app/components/Export/components/ExportToTerra/exportToTerra.tsx
@@ -1,5 +1,6 @@
+import { Loading } from "app/components/Loading/loading";
 import { useRequestFileLocation } from "../../../../hooks/useRequestFileLocation";
-import { RoundedLoading } from "../../../Loading/loading.styles";
+import { PAPER_PANEL_STYLE } from "../../../common/Paper/paper";
 import { ExportToTerraNotStarted } from "./components/ExportToTerraNotStarted/exportToTerraNotStarted";
 import { ExportToTerraReady } from "./components/ExportToTerraReady/exportToTerraReady";
 
@@ -20,7 +21,11 @@ export const ExportToTerra = ({
       {/* Export is idle or loading */}
       {(isIdle || isLoading) && (
         <div>
-          <RoundedLoading loading={isLoading} />
+          <Loading
+            loading={isLoading}
+            panelStyle={PAPER_PANEL_STYLE.FLUID}
+            text="Your link will be ready shortly..."
+          />
           <ExportToTerraNotStarted run={run} />
         </div>
       )}

--- a/explorer/app/components/Loading/loading.stories.tsx
+++ b/explorer/app/components/Loading/loading.stories.tsx
@@ -1,14 +1,19 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { RoundedLoading } from "./loading.styles";
+import { PAPER_PANEL_STYLE } from "../common/Paper/paper";
+import { Loading } from "./loading";
 
 export default {
   argTypes: {
     className: { control: { disabled: true } },
     loading: { control: "boolean" },
+    panelStyle: {
+      control: "select",
+      options: Array.from(Object.keys(PAPER_PANEL_STYLE)),
+    },
     text: { control: "text" },
   },
-  component: RoundedLoading,
+  component: Loading,
   decorators: [
     (Story): JSX.Element => (
       <div
@@ -24,10 +29,10 @@ export default {
     ),
   ],
   title: "Components/Communication/Loading",
-} as ComponentMeta<typeof RoundedLoading>;
+} as ComponentMeta<typeof Loading>;
 
-const Template: ComponentStory<typeof RoundedLoading> = (args) => (
-  <RoundedLoading {...args} />
+const Template: ComponentStory<typeof Loading> = (args) => (
+  <Loading {...args} />
 );
 
 export const DownloadLoading = Template.bind({});

--- a/explorer/app/components/Loading/loading.styles.ts
+++ b/explorer/app/components/Loading/loading.styles.ts
@@ -1,8 +1,17 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { Paper } from "../common/Paper/paper";
-import { Loading } from "./loading";
+import { BREAKPOINT } from "../../hooks/useBreakpointHelper";
+import {
+  Paper,
+  PaperPanelStyle,
+  PAPER_PANEL_STYLE,
+} from "../common/Paper/paper";
 
-export const LoadingBackground = styled(Paper)`
+interface Props {
+  panelStyle: PaperPanelStyle;
+}
+
+export const LoadingBackground = styled(Paper)<Props>`
   background-color: rgba(255, 255, 255, 0.8);
   display: grid;
   gap: 16px;
@@ -13,10 +22,45 @@ export const LoadingBackground = styled(Paper)`
   position: absolute;
   top: 0;
   width: 100%;
-  z-index: 1400;
-`;
+  z-index: 10;
 
-// RoundedPaper styles.
-export const RoundedLoading = styled(Loading)`
-  border-radius: 8px;
+  // Style "Flat" paper.
+  ${({ panelStyle }) =>
+    panelStyle === PAPER_PANEL_STYLE.FLAT &&
+    css`
+      border-left: none;
+      border-radius: 0;
+      border-right: none;
+      box-shadow: none;
+    `};
+
+  // Style "Fluid" paper.
+  ${({ panelStyle, theme }) =>
+    panelStyle === PAPER_PANEL_STYLE.FLUID &&
+    css`
+      border-radius: 8px;
+
+      ${theme.breakpoints.down(BREAKPOINT.TABLET)} {
+        border-left: none;
+        border-radius: 0;
+        border-right: none;
+        box-shadow: none;
+      }
+    `};
+
+  // No style - borderless with no elevation.
+  ${({ panelStyle }) =>
+    panelStyle === PAPER_PANEL_STYLE.NONE &&
+    css`
+      border: 0;
+      border-radius: 0;
+      box-shadow: none;
+    `};
+
+  // Style "Rounded" paper.
+  ${({ panelStyle }) =>
+    panelStyle === PAPER_PANEL_STYLE.ROUNDED &&
+    css`
+      border-radius: 8px;
+    `};
 `;

--- a/explorer/app/components/Loading/loading.tsx
+++ b/explorer/app/components/Loading/loading.tsx
@@ -6,18 +6,19 @@
 import { Typography } from "@mui/material";
 import React, { useEffect, useRef } from "react";
 import { LoadingIcon } from "../common/CustomIcon/components/LoadingIcon/loadingIcon";
+import { PaperPanelStyle, PAPER_PANEL_STYLE } from "../common/Paper/paper";
 import { LoadingBackground } from "./loading.styles";
 
 interface Props {
-  className?: string;
   loading: boolean;
+  panelStyle?: PaperPanelStyle; // Enables loading to mirror parent container styles.
   text?: string;
 }
 
 export const Loading = ({
-  className,
   loading,
-  text = "Your link will be ready shortly...",
+  panelStyle = PAPER_PANEL_STYLE.ROUNDED,
+  text,
 }: Props): JSX.Element | null => {
   const loadingRef = useRef<HTMLDivElement>(null);
   const parentRef = useRef<HTMLElement | null>(null);
@@ -42,9 +43,9 @@ export const Loading = ({
   }, [loading]);
 
   return loading ? (
-    <LoadingBackground className={className} ref={loadingRef}>
+    <LoadingBackground panelStyle={panelStyle} ref={loadingRef}>
       <LoadingIcon color="primary" fontSize="large" />
-      <Typography variant="text-body-400">{text}</Typography>
+      {text && <Typography variant="text-body-400">{text}</Typography>}
     </LoadingBackground>
   ) : null;
 };

--- a/explorer/app/components/Table/table.tsx
+++ b/explorer/app/components/Table/table.tsx
@@ -19,7 +19,7 @@ import React from "react";
 import { Pagination, Sort, SortOrderType } from "../../common/entities";
 import { CheckboxMenu, CheckboxMenuItem } from "../CheckboxMenu/checkboxMenu";
 import { GridPaper, RoundedPaper } from "../common/Paper/paper.styles";
-import { RoundedLoading } from "../Loading/loading.styles";
+import { Loading } from "../Loading/loading";
 import { Pagination as DXPagination } from "./components/Pagination/pagination";
 import { PaginationSummary } from "./components/PaginationSummary/paginationSummary";
 import { newColumnKey, newColumnOrder } from "./functions";
@@ -137,7 +137,7 @@ export const Table = <T extends object>({
 
   return (
     <div>
-      <RoundedLoading loading={loading || false} />
+      <Loading loading={loading || false} />
       <RoundedPaper>
         <GridPaper>
           {editColumns && (

--- a/explorer/app/components/common/Paper/paper.tsx
+++ b/explorer/app/components/common/Paper/paper.tsx
@@ -5,6 +5,21 @@
 import { Paper as Panel, PaperProps } from "@mui/material";
 import React, { forwardRef, ReactNode } from "react";
 
+/**
+ * Model of paper variant "panel" style.
+ */
+export type PaperPanelStyle = keyof typeof PAPER_PANEL_STYLE;
+
+/**
+ * Possible set of paper variant "panel" style values.
+ */
+export enum PAPER_PANEL_STYLE {
+  FLAT = "FLAT",
+  FLUID = "FLUID",
+  NONE = "NONE",
+  ROUNDED = "ROUNDED",
+}
+
 interface Props {
   children: ReactNode | ReactNode[];
   className?: string;


### PR DESCRIPTION
### Ticket
Closes #491.

### Reviewers
@MillenniumFalconMechanic.

### Changes
- Removed `RoundedLoading` styles and modified Loading component to take a prop that defines the loading style.
- Updated Loading zIndex.
- Updated SB.

### Definition of Done (from ticket)
- Loading component renders underneath an open filter menu.
- Loading component does not throw an error when going to `/explore/export/export-to-terra` directly.
