### PR TITLE
Separating fetch entities logic into especific hooks. #495

### DIFF
--- a/explorer/app/components/Table/table.tsx
+++ b/explorer/app/components/Table/table.tsx
@@ -34,11 +34,13 @@ export interface EditColumnConfig {
 
 interface TableProps<T extends object> {
   columns: ColumnDef<T>[];
+  count?: number;
   disablePagination?: boolean;
   editColumns?: EditColumnConfig;
   gridTemplateColumns: string;
   items: T[];
   loading?: boolean;
+  pages?: number;
   pageSize: number;
   pagination?: Pagination;
   sort?: Sort;
@@ -56,6 +58,8 @@ interface TableProps<T extends object> {
  * @param tableProps.editColumns - True if edit column functionality is enabled for table.
  * @param tableProps.pageSize - Number of rows to display per page.
  * @param tableProps.total - Total number of rows in the result set.
+ * @param tableProps.count - Total number of rows in the current page.
+ * @param tableProps.pages - Total amount of pages.
  * @param tableProps.pagination - Config for rendering pagination and corresponding events.
  * @param tableProps.sort - Config for rendering current sort and handling corresponding events.
  * @param tableProps.gridTemplateColumns - Defines grid table track sizing.
@@ -64,11 +68,13 @@ interface TableProps<T extends object> {
  */
 export const Table = <T extends object>({
   columns,
+  count,
   disablePagination,
   editColumns,
   gridTemplateColumns,
   items,
   loading,
+  pages,
   pageSize,
   pagination,
   sort,
@@ -113,6 +119,7 @@ export const Table = <T extends object>({
   const currentPage =
     pagination?.currentPage ?? getState().pagination.pageIndex + 1;
   const totalPage = total ?? getState().pagination.pageSize;
+  const pageCount = count ?? getState().pagination.pageSize;
 
   const handleTableNextPage = (): void => {
     const nextPage = pagination?.nextPage ?? tableNextPage;
@@ -135,6 +142,8 @@ export const Table = <T extends object>({
     }
   };
 
+  const isLastPage = currentPage === pages;
+
   return (
     <div>
       <RoundedLoading loading={loading || false} />
@@ -143,8 +152,8 @@ export const Table = <T extends object>({
           <TableToolbar>
             <PaginationSummary
               firstResult={(currentPage - 1) * pageSize + 1}
-              lastResult={pageSize * currentPage}
-              totalResult={totalPage * pageSize}
+              lastResult={isLastPage ? totalPage : pageCount * currentPage}
+              totalResult={totalPage}
             />
             <CheckboxMenu
               label="Edit Columns"
@@ -213,7 +222,7 @@ export const Table = <T extends object>({
             currentPage={currentPage}
             onNextPage={handleTableNextPage}
             onPreviousPage={handleTablePreviousPage}
-            totalPage={totalPage}
+            totalPage={pages ?? 0}
           />
         )}
       </RoundedPaper>

--- a/explorer/app/components/TableCreator/tableCreator.tsx
+++ b/explorer/app/components/TableCreator/tableCreator.tsx
@@ -15,6 +15,8 @@ interface TableCreatorProps<T> {
   disablePagination?: boolean;
   items: T[];
   loading?: boolean;
+  pageCount?: number;
+  pages: number;
   pageSize: number;
   pagination?: Pagination;
   sort?: Sort;
@@ -65,6 +67,8 @@ export const TableCreator = <T extends object>({
   disablePagination,
   items,
   loading,
+  pageCount,
+  pages,
   pageSize,
   pagination,
   sort,
@@ -91,10 +95,12 @@ export const TableCreator = <T extends object>({
       editColumns={editColumns}
       gridTemplateColumns={gridTemplateColumns}
       items={items}
+      pages={pages}
       pageSize={pageSize}
       pagination={pagination}
       sort={sort}
       total={total}
+      count={pageCount}
       loading={loading}
     />
   );

--- a/explorer/app/hooks/useCategoryFilter.ts
+++ b/explorer/app/hooks/useCategoryFilter.ts
@@ -11,13 +11,18 @@ import {
 } from "../common/entities";
 import { CategoryConfig } from "../config/common/entities";
 import { useConfig } from "./useConfig";
-import { SetFilterFn } from "./useFetchEntities";
+
+/**
+ * State backing filter functionality and calculations. Converted to view model for display.
+ */
+type FilterState = Filters;
 
 /**
  * Shape of return value from this useCategoryFilter hook.
  */
 export interface FilterInstance {
   categories: SelectCategoryView[];
+  filter: FilterState;
   onFilter: OnFilterFn;
 }
 
@@ -31,22 +36,17 @@ export type OnFilterFn = (
 ) => void;
 
 /**
- * State backing filter functionality and calculations. Converted to view model for display.
- */
-type FilterState = Filters;
-
-/**
  * Server-side faceted filter functionality.
  * @param categories - Full set of categories.
- * @param setFilter - Function to call to trigger re-fetch of entities on change of selected filter values.
+ * @param initialFilter - Initial set of select categories.
  * @returns Object container filter accessor (view model of filter state).
  */
 export const useCategoryFilter = (
   categories: SelectCategory[],
-  setFilter: SetFilterFn
+  initialFilter: Filters
 ): FilterInstance => {
   // Complete set of categories and category values to be included for display and filtering.
-  const [filterState, setFilterState] = useState<FilterState>([]);
+  const [filterState, setFilterState] = useState<FilterState>(initialFilter);
 
   // Grab the site config.
   const { categoryConfigs = [] } = useConfig();
@@ -65,13 +65,13 @@ export const useCategoryFilter = (
         selected
       );
       setFilterState(nextFilterState);
-      setFilter(nextFilterState);
     },
-    [filterState, setFilter]
+    [filterState]
   );
 
   return {
     categories: buildCategoryViews(categories, categoryConfigs, filterState),
+    filter: filterState,
     onFilter,
   };
 };

--- a/explorer/app/hooks/useFetchEntities.ts
+++ b/explorer/app/hooks/useFetchEntities.ts
@@ -1,5 +1,4 @@
-import { EntityConfig } from "app/config/common/entities";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import {
   AzulEntitiesResponse,
   AzulEntitiesStaticResponse,
@@ -11,15 +10,17 @@ import {
   transformTermFacets,
 } from "../apis/azul/common/filterTransformer";
 import {
+  CategoryKey,
+  CategoryValueKey,
   Pagination,
   SelectCategory,
   Sort,
-  SortOrderType,
 } from "../common/entities";
 import { useAsync } from "./useAsync";
-import { useCurrentEntity } from "./useCurrentEntity";
+import { OnFilterFn, useCategoryFilter } from "./useCategoryFilter";
 import { useFetcher } from "./useFetcher";
-import { useResetableState } from "./useResetableState";
+import { usePagination } from "./usePagination";
+import { useSort } from "./useSort";
 
 /**
  * Type of function called to update filter query string params and trigger re-fetch of entities.
@@ -32,25 +33,11 @@ export type SetFilterFn = (nextFilters: Filters) => void;
 interface EntitiesResponse {
   categories: SelectCategory[];
   loading: boolean;
+  onFilter: OnFilterFn;
   pagination?: Pagination;
   response?: AzulEntitiesResponse;
-  setFilter: SetFilterFn;
   sort?: Sort;
 }
-
-const DEFAULT_CURRENT_PAGE = 1;
-
-/**
- * Determine the default sort column.
- * @param entity - Current entity config containing all column definitions.
- * @returns Column name of default sorted column, or the first column if no default is specified.
- */
-const getDefaultSort = (entity: EntityConfig): string | undefined => {
-  return (
-    entity.list.columns.find((column) => column.sort?.default)?.sort?.sortKey ??
-    entity.list.columns[0].sort?.sortKey
-  );
-};
 
 /**
  * Hook handling the load and transformation of the values used by index pages. If the current entity loaded statically,
@@ -62,34 +49,29 @@ const getDefaultSort = (entity: EntityConfig): string | undefined => {
 export const useFetchEntities = (
   staticResponse: AzulEntitiesStaticResponse | null,
   initialFilter: Filters
-  // eslint-disable-next-line sonarjs/cognitive-complexity -- TODO revisit with #267.
 ): EntitiesResponse => {
-  // Init pagination-related state.
-  const [currentPage, setCurrentPage] = useState(DEFAULT_CURRENT_PAGE);
-
-  // Init query param-related state. TODO(mim) move to own hook to reduce complexity here, rename setFilterFn
-  const [filter, setFilter] = useState<Filters>(initialFilter);
-  const setFilterFn = useCallback((nextFilter: Filters) => {
-    setFilter(nextFilter);
-  }, []);
-
-  // Grab the current entity.
-  const entity = useCurrentEntity();
-
   // Determine type of fetch to be executed, either API endpoint or TSV.
-  const { fetchList, list, path, staticLoad } = useFetcher();
-
-  // Init sort.
-  const defaultSort = useMemo(() => getDefaultSort(entity), [entity]);
-  const [sortKey, setSortKey] = useResetableState<string | undefined>(
-    defaultSort
-  );
-  const [sortOrder, setSortOrder] = useState<SortOrderType | undefined>(
-    defaultSort ? "asc" : undefined
-  );
+  const { list, path, staticLoad } = useFetcher();
 
   // Init fetch of entities.
   const { data, isIdle, isLoading, run } = useAsync<AzulEntitiesResponse>();
+  const { resetPage, ...pagination } = usePagination(data);
+  const { sort, sortKey, sortOrder } = useSort();
+
+  // Generalize the filters returned from Azul.
+  const categories = useMemo(() => {
+    if (staticLoad || !data) {
+      return [];
+    }
+    return transformTermFacets(data.termFacets);
+  }, [data, staticLoad]);
+
+  // Init filter functionality.
+  const {
+    categories: categoryViews,
+    filter,
+    onFilter,
+  } = useCategoryFilter(categories, initialFilter);
 
   // Execute fetch of entities.
   useEffect(() => {
@@ -108,42 +90,17 @@ export const useFetchEntities = (
     }
   }, [filter, list, path, run, sortKey, sortOrder, staticLoad]);
 
-  // Handle change of sort.
-  const sort = useCallback(
-    (key?: string, order?: SortOrderType) => {
-      setSortKey(key ?? defaultSort);
-      setSortOrder(order);
+  const handleFilterChange = useCallback(
+    (
+      categoryKey: CategoryKey,
+      selectedCategoryValue: CategoryValueKey,
+      selected: boolean
+    ) => {
+      onFilter(categoryKey, selectedCategoryValue, selected);
+      resetPage();
     },
-    [defaultSort, setSortKey]
+    [onFilter, resetPage]
   );
-
-  // Create callback for next page action.
-  const nextPage = useCallback(async () => {
-    if (data?.pagination.next) {
-      setCurrentPage((s) => s + 1);
-      run(fetchList(data.pagination.next));
-    }
-  }, [data?.pagination.next, fetchList, run]);
-
-  // Create callback for previous page action.
-  const previousPage = useCallback(async () => {
-    if (data?.pagination.previous) {
-      setCurrentPage((s) => s - 1);
-      run(fetchList(data.pagination.previous));
-    }
-  }, [data?.pagination.previous, fetchList, run]);
-
-  const resetPage = useCallback(() => {
-    setCurrentPage(DEFAULT_CURRENT_PAGE);
-  }, []);
-
-  // Generalize the filters returned from Azul.
-  const categories = useMemo(() => {
-    if (staticLoad || !data) {
-      return [];
-    }
-    return transformTermFacets(data.termFacets);
-  }, [data, staticLoad]);
 
   // Exit if we're dealing with a statically-loaded entity; data has already been fetched during build; indicate
   // load is complete and return static data.
@@ -151,25 +108,18 @@ export const useFetchEntities = (
     return {
       categories: [],
       loading: false,
+      onFilter,
       response: staticResponse?.data,
-      setFilter: setFilterFn,
     };
   }
 
   // Otherwise, return the fetching, pagination and sort state.
   return {
-    categories,
+    categories: categoryViews,
     loading: isLoading || isIdle,
-    pagination: {
-      canNextPage: !!data?.pagination.next,
-      canPreviousPage: !!data?.pagination.previous,
-      currentPage,
-      nextPage,
-      previousPage,
-      resetPage,
-    },
+    onFilter: handleFilterChange,
+    pagination: { ...pagination, resetPage },
     response: data,
-    setFilter: setFilterFn,
     sort: {
       sort,
       sortKey,

--- a/explorer/app/hooks/usePagination.ts
+++ b/explorer/app/hooks/usePagination.ts
@@ -1,0 +1,46 @@
+import { AzulEntitiesResponse } from "app/apis/azul/common/entities";
+import { Pagination } from "app/common/entities";
+import { useCallback, useState } from "react";
+import { useAsync } from "./useAsync";
+import { useFetcher } from "./useFetcher";
+
+const DEFAULT_CURRENT_PAGE = 1;
+
+export const usePagination = (data?: AzulEntitiesResponse): Pagination => {
+  const { run } = useAsync<AzulEntitiesResponse>();
+
+  // Determine type of fetch to be executed, either API endpoint or TSV.
+  const { fetchList } = useFetcher();
+
+  // Init pagination-related state.
+  const [currentPage, setCurrentPage] = useState(DEFAULT_CURRENT_PAGE);
+
+  // Create callback for next page action.
+  const nextPage = useCallback(async () => {
+    if (data?.pagination.next) {
+      setCurrentPage((s) => s + 1);
+      run(fetchList(data.pagination.next));
+    }
+  }, [data?.pagination.next, fetchList, run]);
+
+  // Create callback for previous page action.
+  const previousPage = useCallback(async () => {
+    if (data?.pagination.previous) {
+      setCurrentPage((s) => s - 1);
+      run(fetchList(data.pagination.previous));
+    }
+  }, [data?.pagination.previous, fetchList, run]);
+
+  const resetPage = useCallback(() => {
+    setCurrentPage(DEFAULT_CURRENT_PAGE);
+  }, []);
+
+  return {
+    canNextPage: !!data?.pagination.next,
+    canPreviousPage: !!data?.pagination.previous,
+    currentPage,
+    nextPage,
+    previousPage,
+    resetPage,
+  };
+};

--- a/explorer/app/hooks/useSort.ts
+++ b/explorer/app/hooks/useSort.ts
@@ -1,0 +1,46 @@
+import { Sort, SortOrderType } from "app/common/entities";
+import { EntityConfig } from "app/config/common/entities";
+import { useCallback, useMemo, useState } from "react";
+import { useCurrentEntity } from "./useCurrentEntity";
+import { useResetableState } from "./useResetableState";
+
+/**
+ * Determine the default sort column.
+ * @param entity - Current entity config containing all column definitions.
+ * @returns Column name of default sorted column, or the first column if no default is specified.
+ */
+const getDefaultSort = (entity: EntityConfig): string | undefined => {
+  return (
+    entity.list.columns.find((column) => column.sort?.default)?.sort?.sortKey ??
+    entity.list.columns[0].sort?.sortKey
+  );
+};
+
+export const useSort = (): Sort => {
+  // Grab the current entity.
+  const entity = useCurrentEntity();
+
+  // Init sort.
+  const defaultSort = useMemo(() => getDefaultSort(entity), [entity]);
+  const [sortKey, setSortKey] = useResetableState<string | undefined>(
+    defaultSort
+  );
+  const [sortOrder, setSortOrder] = useState<SortOrderType | undefined>(
+    defaultSort ? "asc" : undefined
+  );
+
+  // Handle change of sort.
+  const sort = useCallback(
+    (key?: string, order?: SortOrderType) => {
+      setSortKey(key ?? defaultSort);
+      setSortOrder(order);
+    },
+    [defaultSort, setSortKey]
+  );
+
+  return {
+    sort,
+    sortKey,
+    sortOrder,
+  };
+};

--- a/explorer/app/views/Index/index.tsx
+++ b/explorer/app/views/Index/index.tsx
@@ -136,9 +136,11 @@ export const Index = (props: AzulEntitiesStaticResponse): JSX.Element => {
         columns={columnsConfig}
         items={entitiesResponse.hits}
         pageSize={entitiesResponse.pagination.size}
-        total={entitiesResponse.pagination.pages}
+        total={entitiesResponse.pagination.total}
+        pageCount={entitiesResponse.pagination.count}
         pagination={pagination}
         sort={sort}
+        pages={entitiesResponse.pagination.pages}
         loading={loading}
         disablePagination={config.disablePagination}
       />

--- a/explorer/app/views/Index/index.tsx
+++ b/explorer/app/views/Index/index.tsx
@@ -24,7 +24,6 @@ import { Index as IndexView } from "../../components/Index/index";
 import { SidebarLabel } from "../../components/Layout/components/Sidebar/components/SidebarLabel/sidebarLabel";
 import { Sidebar } from "../../components/Layout/components/Sidebar/sidebar";
 import { EntityConfig, SummaryConfig } from "../../config/common/entities";
-import { useCategoryFilter } from "../../hooks/useCategoryFilter";
 
 /**
  * Returns tabs to be used as a prop for the Tabs component.
@@ -80,14 +79,8 @@ export const Index = (props: AzulEntitiesStaticResponse): JSX.Element => {
 
   // Fetch summary and entities.
   const { response: summaryResponse } = useSummary();
-  const { categories, loading, pagination, response, setFilter, sort } =
+  const { categories, loading, onFilter, pagination, response, sort } =
     useFetchEntities(props, []);
-
-  // Init filter functionality.
-  const { categories: categoryViews, onFilter } = useCategoryFilter(
-    categories,
-    setFilter
-  );
 
   // Grab the column config for the current entity.
   const columnsConfig = entity?.list?.columns;
@@ -154,9 +147,9 @@ export const Index = (props: AzulEntitiesStaticResponse): JSX.Element => {
 
   return (
     <>
-      {categoryViews && !!categoryViews.length && (
+      {categories && !!categories.length && (
         <Sidebar Label={<SidebarLabel label={"Filters"} />}>
-          <Filters categories={categoryViews} onFilter={onFilter} />
+          <Filters categories={categories} onFilter={onFilter} />
         </Sidebar>
       )}
       <IndexView


### PR DESCRIPTION
### Ticket
Closes #495 

### Reviewers
@.

### Changes
- Resetting pagination on filter change
- Moving listing hooks from `useFetchEntities` to their own hook
- `useFetchEntities` is now an aggregation hook for things related to the listing
- Fixing summary values

### Definition of Done (from ticket)

### QA steps (optional)

### Known Issues
