### PR TITLE
Added mock tabs for CAVITACA and Curl, but not displayed correctly ye…

### DIFF
--- a/explorer/app/viewModelBuilders/azul/anvil/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/anvil/common/viewModelBuilders.ts
@@ -420,6 +420,16 @@ export const buildReportedEthnicities = (
   };
 };
 
+export const buildExportToCurlCommand = (): React.ComponentProps<
+  typeof C.ExportMethod
+> => ({
+  buttonLabel: "Request curl Command",
+  description: "Obtain a curl command for downloading the selected data.",
+  disabled: false,
+  route: "/export",
+  title: "Download Study Data and Metadata (Curl Command)",
+});
+
 export const buildExportToTerraMetadata = (): React.ComponentProps<
   typeof C.ExportMethod
 > => ({
@@ -429,4 +439,14 @@ export const buildExportToTerraMetadata = (): React.ComponentProps<
   disabled: false,
   route: "/export/export-to-terra",
   title: "Export Study Data and Metadata to Terra Workspace",
+});
+
+export const buildExportToCaviticaMetadata = (): React.ComponentProps<
+  typeof C.ExportMethod
+> => ({
+  buttonLabel: "Analyze in CAVATICA",
+  description: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit.",
+  disabled: false,
+  route: "/export",
+  title: "Export to CAVATICA",
 });

--- a/explorer/site-config/anvil/dev/export/export.ts
+++ b/explorer/site-config/anvil/dev/export/export.ts
@@ -9,7 +9,15 @@ export const exportConfig: BackPageConfig = {
       mainColumn: [
         {
           component: C.ExportMethod,
+          viewBuilder: T.buildExportToCurlCommand,
+        } as ComponentConfig<typeof C.ExportMethod>,
+        {
+          component: C.ExportMethod,
           viewBuilder: T.buildExportToTerraMetadata,
+        } as ComponentConfig<typeof C.ExportMethod>,
+        {
+          component: C.ExportMethod,
+          viewBuilder: T.buildExportToCaviticaMetadata,
         } as ComponentConfig<typeof C.ExportMethod>,
       ],
       route: "/export",


### PR DESCRIPTION
…t #500

### Ticket
Closes #500 .

### Reviewers
@frano-m .

### Changes
- Added mock buttons to AnVIL export button for CAVATICA and Curl

### Definition of Done (from ticket)

1. User can see both request curl command and analyze in Cavitica export options as per the above mocks, configured similarly to the "Export to Terra."
2. Selecting the button actually to export does nothing.
3. Images in Terra/Cavitica are out of scope.

### Known Issues
- Spacing incorrect between buttons, images not present