### PR TITLE
Make ExportToTerraPage side column config reference DataReleasePolicy component. #505.

### DIFF
--- a/explorer/app/components/Project/components/DataReleasePolicy/dataReleasePolicy.tsx
+++ b/explorer/app/components/Project/components/DataReleasePolicy/dataReleasePolicy.tsx
@@ -11,6 +11,7 @@ export const DataReleasePolicy = (): JSX.Element => {
         <Link href="https://anvilproject.org/faq/data-security/" passHref>
           <PolicyLink target="_blank">Data Access Policy</PolicyLink>
         </Link>
+        .
       </Typography>
     </Section>
   );

--- a/explorer/app/views/ExportToTerraPage/sideColumn.tsx
+++ b/explorer/app/views/ExportToTerraPage/sideColumn.tsx
@@ -1,7 +1,11 @@
-// TODO review use of data release policy stories component
-import { ProjectDataReleasePolicy } from "app/components/Project/components/DataReleasePolicy/dataReleasePolicy.stories";
+import { FluidPaper } from "app/components/common/Paper/paper.styles";
 import React from "react";
+import { DataReleasePolicy } from "../../components";
 
 export const SideColumn = (): JSX.Element => {
-  return <ProjectDataReleasePolicy />;
+  return (
+    <FluidPaper>
+      <DataReleasePolicy />
+    </FluidPaper>
+  );
 };


### PR DESCRIPTION

### Ticket
Closes #505.

### Reviewers
@MillenniumFalconMechanic.

### Changes
- Removed DataReleasePolicy SB from side column and added corresponding component.
- Added paper styles around the policy component to render within its own container.

### Definition of Done (from ticket)
- SB is replaced by DataReleasePolicy.