### PR TITLE
415 column styles

### DIFF
--- a/explorer/app/components/Detail/components/Sections/sections.tsx
+++ b/explorer/app/components/Detail/components/Sections/sections.tsx
@@ -1,0 +1,18 @@
+import {
+  FluidPaper,
+  GridPaper,
+} from "app/components/common/Paper/paper.styles";
+import React, { ReactNode } from "react";
+
+interface Props {
+  children: ReactNode | ReactNode[];
+  className?: string;
+}
+
+export const Sections = ({ children, className }: Props): JSX.Element => {
+  return (
+    <FluidPaper className={className}>
+      <GridPaper>{children}</GridPaper>
+    </FluidPaper>
+  );
+};

--- a/explorer/app/components/Detail/detail.tsx
+++ b/explorer/app/components/Detail/detail.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from "react";
 import { BackPageView } from "../Layout/components/BackPage/backPageView";
 
 interface Props {
+  isDetailOverview?: boolean;
   mainColumn: ReactNode;
   sideColumn: ReactNode;
   Tabs?: ReactNode;
@@ -9,6 +10,7 @@ interface Props {
 }
 
 export const Detail = ({
+  isDetailOverview,
   mainColumn,
   sideColumn,
   Tabs,
@@ -16,6 +18,7 @@ export const Detail = ({
 }: Props): JSX.Element => {
   return (
     <BackPageView
+      isDetailOverview={isDetailOverview}
       mainColumn={mainColumn}
       sideColumn={sideColumn}
       Tabs={Tabs}

--- a/explorer/app/components/Layout/components/BackPage/backPageView.styles.ts
+++ b/explorer/app/components/Layout/components/BackPage/backPageView.styles.ts
@@ -1,5 +1,7 @@
+import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { BREAKPOINT } from "../../../../hooks/useBreakpointHelper";
+import { Sections } from "../../../Detail/components/Sections/sections";
 
 export const BackPageView = styled.div`
   display: grid;
@@ -33,7 +35,8 @@ export const BackPageTabs = styled.div`
   }
 `;
 
-export const BackPageOverview = styled.div`
+// Back page content (main and side column wrapper).
+export const BackPageContent = styled.div`
   align-items: flex-start;
   display: grid;
   gap: 16px 0;
@@ -50,20 +53,89 @@ export const BackPageOverview = styled.div`
   }
 `;
 
-const BackPageOverviewColumn = styled.div`
+// Detail back page "overview" content (main and side column wrapper).
+// Typically used by back page "project" or "datasets" tab.
+// Used with DetailPageOverviewContentMainColumn and DetailPageOverviewContentSideColumn, the "sections"
+// appear to be contained within a combination of "fluid" and "gridded" paper elements.
+// These styles render:
+// - mobile - a gridded, flat paper environment, each section stacked with a 1px gap, and
+// - tablet - a main and side column arrangement, and within each column, a gridded, rounded paper environment, each section stacked with a 1px gap.
+export const DetailPageOverviewContent = styled(BackPageContent)`
+  background-color: ${({ theme }) => theme.palette.smoke.main};
+  gap: 1px;
+  padding: 1px 0;
+
+  ${({ theme }) => theme.breakpoints.up(BREAKPOINT.TABLET)} {
+    background-color: transparent;
+    padding: 0;
+  }
+`;
+
+// Back page content column.
+const BackPageContentColumn = styled.div`
   display: flex;
   flex-direction: column;
   gap: 16px 0;
 `;
 
-export const BackPageOverviewMain = styled(BackPageOverviewColumn)`
+const mainColumn = css`
+  grid-column: 1 / 9;
+`;
+
+const sideColumn = css`
+  grid-column: 9 / -1;
+`;
+
+// Main column.
+export const BackPageContentMainColumn = styled(BackPageContentColumn)`
   ${({ theme }) => theme.breakpoints.up(BREAKPOINT.TABLET)} {
-    grid-column: 1 / 9;
+    ${mainColumn};
   }
 `;
 
-export const BackPageOverviewSide = styled(BackPageOverviewColumn)`
+// Side column.
+export const BackPageContentSideColumn = styled(BackPageContentColumn)`
   ${({ theme }) => theme.breakpoints.up(BREAKPOINT.TABLET)} {
-    grid-column: 9 / -1;
+    ${sideColumn};
+  }
+`;
+
+// Detail back page "overview" main column.
+// Typically used by back page "project" or "datasets" tab.
+export const DetailPageOverviewContentMainColumn = styled(Sections)`
+  display: contents;
+
+  && > * {
+    display: contents; // required to override nested GridPaper.
+  }
+
+  ${({ theme }) => theme.breakpoints.up(BREAKPOINT.TABLET)} {
+    align-self: flex-start;
+    display: grid;
+    ${mainColumn};
+
+    && > * {
+      display: grid; // required to restore nested GridPaper display property.
+    }
+  }
+`;
+
+// Detail back page "overview" side column.
+// Typically used by back page "project" or "datasets" tab.
+export const DetailPageOverviewContentSideColumn = styled(Sections)`
+  display: contents;
+
+  && > * {
+    display: contents; // required to override nested GridPaper.
+  }
+
+  ${({ theme }) => theme.breakpoints.up(BREAKPOINT.TABLET)} {
+    align-self: flex-start;
+    display: grid;
+    ${sideColumn};
+
+    && > * {
+      display: grid; // required to restore nested GridPaper display property.
+    }
   }
 `;

--- a/explorer/app/components/Layout/components/BackPage/backPageView.styles.ts
+++ b/explorer/app/components/Layout/components/BackPage/backPageView.styles.ts
@@ -1,9 +1,9 @@
 import styled from "@emotion/styled";
 import { BREAKPOINT } from "../../../../hooks/useBreakpointHelper";
-import { RoundedPaper } from "../../../common/Paper/paper.styles";
 
 export const BackPageView = styled.div`
   display: grid;
+  flex: 1;
   gap: 16px;
   grid-template-columns: repeat(2, 1fr);
   margin: 0 16px;
@@ -24,8 +24,19 @@ export const BackPageHero = styled.div`
   }
 `;
 
+export const BackPageTabs = styled.div`
+  grid-column: 1 / -1;
+
+  ${({ theme }) => theme.breakpoints.down(BREAKPOINT.TABLET)} {
+    margin-left: -16px;
+    margin-right: -16px;
+  }
+`;
+
 export const BackPageOverview = styled.div`
   align-items: flex-start;
+  display: grid;
+  gap: 16px 0;
   grid-column: 1 / -1;
   grid-template-columns: 1fr;
   margin-left: -16px;
@@ -39,13 +50,19 @@ export const BackPageOverview = styled.div`
   }
 `;
 
-export const BackPageOverviewMain = styled(RoundedPaper)`
+const BackPageOverviewColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px 0;
+`;
+
+export const BackPageOverviewMain = styled(BackPageOverviewColumn)`
   ${({ theme }) => theme.breakpoints.up(BREAKPOINT.TABLET)} {
     grid-column: 1 / 9;
   }
 `;
 
-export const BackPageOverviewSide = styled(RoundedPaper)`
+export const BackPageOverviewSide = styled(BackPageOverviewColumn)`
   ${({ theme }) => theme.breakpoints.up(BREAKPOINT.TABLET)} {
     grid-column: 9 / -1;
   }

--- a/explorer/app/components/Layout/components/BackPage/backPageView.tsx
+++ b/explorer/app/components/Layout/components/BackPage/backPageView.tsx
@@ -1,19 +1,18 @@
-import React, { Fragment, ReactNode } from "react";
+import React, { ReactNode } from "react";
 import {
-  BREAKPOINT,
-  BREAKPOINT_FN_NAME,
-  useBreakpointHelper,
-} from "../../../../hooks/useBreakpointHelper";
-import {
+  BackPageContent,
+  BackPageContentMainColumn,
+  BackPageContentSideColumn,
   BackPageHero,
-  BackPageOverview,
-  BackPageOverviewMain as Main,
-  BackPageOverviewSide as Side,
   BackPageTabs,
   BackPageView as BackPageLayout,
+  DetailPageOverviewContent,
+  DetailPageOverviewContentMainColumn,
+  DetailPageOverviewContentSideColumn,
 } from "./backPageView.styles";
 
 interface Props {
+  isDetailOverview?: boolean;
   mainColumn: ReactNode;
   sideColumn: ReactNode;
   Tabs?: ReactNode;
@@ -21,22 +20,29 @@ interface Props {
 }
 
 export const BackPageView = ({
+  isDetailOverview = false,
   mainColumn,
   sideColumn,
   Tabs,
   top,
 }: Props): JSX.Element => {
-  const tablet = useBreakpointHelper(BREAKPOINT_FN_NAME.UP, BREAKPOINT.TABLET);
-  const BackPageOverviewMain = tablet ? Main : Fragment;
-  const BackPageOverviewSide = tablet ? Side : Fragment;
+  const Content = isDetailOverview
+    ? DetailPageOverviewContent
+    : BackPageContent;
+  const MainColumn = isDetailOverview
+    ? DetailPageOverviewContentMainColumn
+    : BackPageContentMainColumn;
+  const SideColumn = isDetailOverview
+    ? DetailPageOverviewContentSideColumn
+    : BackPageContentSideColumn;
   return (
     <BackPageLayout>
       <BackPageHero>{top}</BackPageHero>
       {Tabs && <BackPageTabs>{Tabs}</BackPageTabs>}
-      <BackPageOverview>
-        <BackPageOverviewMain>{mainColumn}</BackPageOverviewMain>
-        <BackPageOverviewSide>{sideColumn}</BackPageOverviewSide>
-      </BackPageOverview>
+      <Content>
+        <MainColumn>{mainColumn}</MainColumn>
+        <SideColumn>{sideColumn}</SideColumn>
+      </Content>
     </BackPageLayout>
   );
 };

--- a/explorer/app/components/Layout/components/BackPage/backPageView.tsx
+++ b/explorer/app/components/Layout/components/BackPage/backPageView.tsx
@@ -4,12 +4,12 @@ import {
   BREAKPOINT_FN_NAME,
   useBreakpointHelper,
 } from "../../../../hooks/useBreakpointHelper";
-import { FlatPaper } from "../../../common/Paper/paper.styles";
 import {
   BackPageHero,
-  BackPageOverview as Overview,
+  BackPageOverview,
   BackPageOverviewMain as Main,
   BackPageOverviewSide as Side,
+  BackPageTabs,
   BackPageView as BackPageLayout,
 } from "./backPageView.styles";
 
@@ -27,17 +27,12 @@ export const BackPageView = ({
   top,
 }: Props): JSX.Element => {
   const tablet = useBreakpointHelper(BREAKPOINT_FN_NAME.UP, BREAKPOINT.TABLET);
-  const BackPageOverview = tablet
-    ? Overview
-    : Overview.withComponent(FlatPaper);
   const BackPageOverviewMain = tablet ? Main : Fragment;
   const BackPageOverviewSide = tablet ? Side : Fragment;
   return (
     <BackPageLayout>
-      <BackPageHero>
-        {top}
-        {Tabs}
-      </BackPageHero>
+      <BackPageHero>{top}</BackPageHero>
+      {Tabs && <BackPageTabs>{Tabs}</BackPageTabs>}
       <BackPageOverview>
         <BackPageOverviewMain>{mainColumn}</BackPageOverviewMain>
         <BackPageOverviewSide>{sideColumn}</BackPageOverviewSide>

--- a/explorer/app/config/common/entities.ts
+++ b/explorer/app/config/common/entities.ts
@@ -84,6 +84,7 @@ export interface DataSourceConfig {
  * Interface to define the set of components that will be used for the back page.
  */
 export interface BackPageConfig {
+  detailOverviews?: TabConfig["label"][];
   tabs: BackPageTabConfig[];
   top: ComponentsConfig;
 }

--- a/explorer/app/theme/theme.ts
+++ b/explorer/app/theme/theme.ts
@@ -203,6 +203,7 @@ export const getAppTheme = (customTheme?: ThemeOptions): Theme => {
    */
   const breakpointUpDesktop = defaultTheme.breakpoints.up(BREAKPOINT.DESKTOP);
   const breakpointUpMobile = defaultTheme.breakpoints.up(BREAKPOINT.MOBILE);
+  const breakpointUpTablet = defaultTheme.breakpoints.up(BREAKPOINT.TABLET);
 
   /**
    * Color constants
@@ -735,6 +736,13 @@ export const getAppTheme = (customTheme?: ThemeOptions): Theme => {
             boxShadow: strokeBottomSmoke,
             minHeight: "unset",
             position: "relative", // Positions scroll fuzz.
+          },
+          scroller: {
+            margin: "0 16px",
+            // eslint-disable-next-line sort-keys -- disabling key order for readability
+            [breakpointUpTablet]: {
+              margin: 0,
+            },
           },
         },
       },

--- a/explorer/app/views/Detail/detail.tsx
+++ b/explorer/app/views/Detail/detail.tsx
@@ -35,6 +35,9 @@ export const Detail = (props: AzulEntityStaticResponse): JSX.Element => {
   const { push, query } = useRouter();
   const entityRoute = entity.route;
   const uuid = query.params?.[PARAMS_INDEX_UUID];
+  const isDetailOverview = entity.detail.detailOverviews?.includes(
+    currentTab.label
+  );
   const mainColumn = currentTab.mainColumn;
   const sideColumn = currentTab.sideColumn;
   const tabs = getTabs(entity);
@@ -57,6 +60,7 @@ export const Detail = (props: AzulEntityStaticResponse): JSX.Element => {
 
   return (
     <DetailView
+      isDetailOverview={isDetailOverview}
       mainColumn={
         <ComponentCreator components={mainColumn} response={response} />
       }

--- a/explorer/site-config/anvil/dev/index/datasetsEntityConfig.ts
+++ b/explorer/site-config/anvil/dev/index/datasetsEntityConfig.ts
@@ -16,6 +16,7 @@ import { top } from "../detail/dataset/top";
 export const datasetsEntityConfig: EntityConfig<DatasetsResponse> = {
   apiPath: "index/datasets",
   detail: {
+    detailOverviews: ["Overview"],
     tabs: [
       {
         label: "Overview",

--- a/explorer/site-config/hca-dcp/dev/projectsEntity.ts
+++ b/explorer/site-config/hca-dcp/dev/projectsEntity.ts
@@ -27,6 +27,7 @@ import * as B from "./projectViewModelBuilder";
 export const projectsEntity: EntityConfig = {
   apiPath: "index/projects",
   detail: {
+    detailOverviews: ["Overview"],
     tabs: [
       {
         label: "Overview",


### PR DESCRIPTION
### Ticket
Closes #415.

### Reviewers
@MillenniumFalconMechanic.

### Changes
- Refactored back page styles to handle the rendering of two distinct layouts:
  - a specialist detail "Overview" page, and
  - any other back page.
- Modified config `detail` with additional property that facilitates the ability to specify which back pages should render the specialist detail page.
- Updated Tabs to match mobile mocks.

### Definition of Done (from ticket)
- Back pages have two styles for their content: columns that render any child stacked with a 16px gap, and the specialist column that renders children stacked directly on top of each other and contained within a styled "gridded" paper element.

### Known Issues
- The use of DataReleasePolicy on the export to terra pages "bleeds" outside of the rounded paper style. May be resolved with #400.