### PR TITLE
525 update fetchlist to take http method

### DIFF
--- a/explorer/app/config/common/entities.ts
+++ b/explorer/app/config/common/entities.ts
@@ -31,6 +31,7 @@ export interface EntityConfig<D = any> extends TabConfig {
   detail: BackPageConfig;
   getId?: GetIdFunction<D>;
   list: ListConfig;
+  options?: Options;
   staticLoad?: boolean;
   tsv?: {
     path: string;
@@ -169,4 +170,10 @@ export interface SiteConfig {
   redirectRootToPath?: string;
   summaryConfig?: SummaryConfig;
   theme?: ThemeOptions;
+}
+
+export type ApiOption = "GET" | "POST";
+
+export interface Options {
+  method: ApiOption;
 }

--- a/explorer/app/entity/api/service.ts
+++ b/explorer/app/entity/api/service.ts
@@ -16,7 +16,7 @@ import {
 import { convertUrlParams } from "../../utils/url";
 
 /**
- * Request to get a list of entities.
+ * Make a GET or POST request for a list of entities
  * @param apiPath - Path that will be used to compose the API url
  * @param listParams - Params to be used on the request. If none passed, it will default to page's size 25 and the current catalog version
  * @param options - String with the type of API call, must be either GET or POST for now
@@ -43,9 +43,9 @@ export const fetchList = async (
   params?: Record<string, string>,
   options?: Options
 ): Promise<AzulEntitiesResponse> => {
-  if (options?.method == "GET" || options?.method == undefined) {
-    const url_with_params = `${url}?${convertUrlParams(params ?? {})}`;
-    const res = await fetch(url_with_params);
+  if (options?.method === "GET" || options?.method === undefined) {
+    const urlWithParams = `${url}?${convertUrlParams(params ?? {})}`;
+    const res = await fetch(urlWithParams);
     return await res.json();
   } else {
     const res = await fetch(url, {

--- a/explorer/app/entity/api/service.ts
+++ b/explorer/app/entity/api/service.ts
@@ -45,14 +45,9 @@ export const fetchList = async (
   options?: Options
 ): Promise<AzulEntitiesResponse> => {
   console.log("I'm making an API call!"); //TODO: get rid of this
-  if (typeof options !== undefined) {
-    const res = await fetch(url, options);
-    console.log(`It's a ${options?.method} call!`); //TODO: get rid of this
-    return await res.json();
-  } else {
-    const res = await fetch(url);
-    return await res.json();
-  }
+  const res = await fetch(url, options);
+  console.log(`It's a ${options?.method} call!`); //TODO: get rid of this
+  return await res.json();
 };
 
 /**

--- a/explorer/app/entity/api/service.ts
+++ b/explorer/app/entity/api/service.ts
@@ -7,7 +7,7 @@ import {
   AzulListParams,
   AzulSummaryResponse,
 } from "../../apis/azul/common/entities";
-import { ApiOption } from "../../config/common/entities";
+import { Options } from "../../config/common/entities";
 import {
   DEFAULT_DETAIL_PARAMS,
   DEFAULT_LIST_PARAMS,
@@ -19,35 +19,35 @@ import { convertUrlParams } from "../../utils/url";
  * Request to get a list of entities.
  * @param apiPath - Path that will be used to compose the API url
  * @param listParams - Params to be used on the request. If none passed, it will default to page's size 25 and the current catalog version
- * @param method - String with the type of API call, must be either GET or POST for now
+ * @param options - String with the type of API call, must be either GET or POST for now
  * @returns @see ListResponseType
  */
 export const list = async (
   apiPath: string,
   listParams?: AzulListParams,
-  method?: ApiOption
+  options?: Options
 ): Promise<AzulEntitiesResponse> => {
   const params = { ...DEFAULT_LIST_PARAMS, ...listParams };
   return await fetchList(
     `${URL}${apiPath}?${convertUrlParams(params)}`,
-    method
+    options
   );
 };
 
 /**
  * Make a get request to get a list of entities.
  * @param url - Absolute URL to be used on the request
- * @param method - String with the type of API call, must be either GET or POST for now
+ * @param options - String with the type of API call, must be either GET or POST for now
  * @returns JSON representation of request list.
  */
 export const fetchList = async (
   url: string,
-  method?: ApiOption
+  options?: Options
 ): Promise<AzulEntitiesResponse> => {
-  console.log("I'm making a call!"); //TODO: get rid of this
-  if (typeof method !== undefined) {
-    const res = await fetch(url, { method: method });
-    console.log(`It's a ${method} call!`); //TODO: get rid of this
+  console.log("I'm making an API call!"); //TODO: get rid of this
+  if (typeof options !== undefined) {
+    const res = await fetch(url, options);
+    console.log(`It's a ${options?.method} call!`); //TODO: get rid of this
     return await res.json();
   } else {
     const res = await fetch(url);
@@ -59,16 +59,16 @@ export const fetchList = async (
  * Recursively call the endpoint to get a list of entities. This will iterate over the entity list until the next entity comes null
  * @param apiPath - Path that will be used to compose the API url
  * @param listParams - Params to be used on the request. If none passed, it will default to page's size 25 and the current catalog version
- * @param method - String with the type of API call, must be either GET or POST for now
+ * @param options - String with the type of API call, must be either GET or POST for now
  * @returns @see ListResponseType
  */
 export const listAll = async (
   apiPath: string,
   listParams?: AzulListParams,
-  method?: ApiOption
+  options?: Options
 ): Promise<AzulEntitiesResponse> => {
   let hits = [];
-  const result = await list(apiPath, listParams, method);
+  const result = await list(apiPath, listParams, options);
   hits = result.hits;
   let nextPage = result.pagination.next;
   while (nextPage) {
@@ -84,20 +84,20 @@ export const listAll = async (
  *  Request to get a single project.
  * @param id - project's uuid.
  * @param apiPath - API endpoint URL.
- * @param method - The method to use to make the API call, right now either GET or POST
+ * @param options - The method to use to make the API call, right now either GET or POST
  * @param param - Catalog's version, if none passed it will default to the current one.
  * @returns @see ProjectResponse
  */
 export const detail = async (
   id: string,
   apiPath: string,
-  method?: ApiOption,
+  options?: Options,
   param = DEFAULT_DETAIL_PARAMS
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- this response type can't be determined beforehand
 ): Promise<any> => {
   const res = await fetch(
     `${URL}${apiPath}/${id}?${convertUrlParams({ ...param })}`,
-    { method: method }
+    options
   );
   return await res.json();
 };

--- a/explorer/app/entity/api/service.ts
+++ b/explorer/app/entity/api/service.ts
@@ -28,26 +28,33 @@ export const list = async (
   options?: Options
 ): Promise<AzulEntitiesResponse> => {
   const params = { ...DEFAULT_LIST_PARAMS, ...listParams };
-  return await fetchList(
-    `${URL}${apiPath}?${convertUrlParams(params)}`,
-    options
-  );
+  return await fetchList(`${URL}${apiPath}`, params, options);
 };
 
 /**
  * Make a get request to get a list of entities.
  * @param url - Absolute URL to be used on the request
+ * @param params - The parameters to be used for the API call
  * @param options - String with the type of API call, must be either GET or POST for now
  * @returns JSON representation of request list.
  */
 export const fetchList = async (
   url: string,
+  params?: Record<string, string>,
   options?: Options
 ): Promise<AzulEntitiesResponse> => {
-  console.log("I'm making an API call!"); //TODO: get rid of this
-  const res = await fetch(url, options);
-  console.log(`It's a ${options?.method} call!`); //TODO: get rid of this
-  return await res.json();
+  if (options?.method == "GET" || options?.method == undefined) {
+    const url_with_params = `${url}?${convertUrlParams(params ?? {})}`;
+    const res = await fetch(url_with_params);
+    return await res.json();
+  } else {
+    const res = await fetch(url, {
+      ...options,
+      body: JSON.stringify(params),
+      headers: { "Content-Type": "application/json" },
+    });
+    return await res.json();
+  }
 };
 
 /**

--- a/explorer/app/entity/api/service.ts
+++ b/explorer/app/entity/api/service.ts
@@ -7,6 +7,7 @@ import {
   AzulListParams,
   AzulSummaryResponse,
 } from "../../apis/azul/common/entities";
+import { ApiOption } from "../../config/common/entities";
 import {
   DEFAULT_DETAIL_PARAMS,
   DEFAULT_LIST_PARAMS,
@@ -31,11 +32,20 @@ export const list = async (
 /**
  * Make a get request to get a list of entities.
  * @param url - Absolute URL to be used on the request
+ * @param method - Method to be used for the request, either GET or POST for now
  * @returns JSON representation of request list.
  */
-export const fetchList = async (url: string): Promise<AzulEntitiesResponse> => {
-  const res = await fetch(url);
-  return await res.json();
+export const fetchList = async (
+  url: string,
+  method?: ApiOption
+): Promise<AzulEntitiesResponse> => {
+  if (typeof method !== undefined) {
+    const res = await fetch(url, { method: method });
+    return await res.json(); //TODO: make this less bad
+  } else {
+    const res = await fetch(url);
+    return await res.json();
+  }
 };
 
 /**

--- a/explorer/app/entity/api/service.ts
+++ b/explorer/app/entity/api/service.ts
@@ -19,29 +19,36 @@ import { convertUrlParams } from "../../utils/url";
  * Request to get a list of entities.
  * @param apiPath - Path that will be used to compose the API url
  * @param listParams - Params to be used on the request. If none passed, it will default to page's size 25 and the current catalog version
+ * @param method - String with the type of API call, must be either GET or POST for now
  * @returns @see ListResponseType
  */
 export const list = async (
   apiPath: string,
-  listParams?: AzulListParams
+  listParams?: AzulListParams,
+  method?: ApiOption
 ): Promise<AzulEntitiesResponse> => {
   const params = { ...DEFAULT_LIST_PARAMS, ...listParams };
-  return await fetchList(`${URL}${apiPath}?${convertUrlParams(params)}`);
+  return await fetchList(
+    `${URL}${apiPath}?${convertUrlParams(params)}`,
+    method
+  );
 };
 
 /**
  * Make a get request to get a list of entities.
  * @param url - Absolute URL to be used on the request
- * @param method - Method to be used for the request, either GET or POST for now
+ * @param method - String with the type of API call, must be either GET or POST for now
  * @returns JSON representation of request list.
  */
 export const fetchList = async (
   url: string,
   method?: ApiOption
 ): Promise<AzulEntitiesResponse> => {
+  console.log("I'm making a call!"); //TODO: get rid of this
   if (typeof method !== undefined) {
     const res = await fetch(url, { method: method });
-    return await res.json(); //TODO: make this less bad
+    console.log(`It's a ${method} call!`); //TODO: get rid of this
+    return await res.json();
   } else {
     const res = await fetch(url);
     return await res.json();
@@ -52,14 +59,16 @@ export const fetchList = async (
  * Recursively call the endpoint to get a list of entities. This will iterate over the entity list until the next entity comes null
  * @param apiPath - Path that will be used to compose the API url
  * @param listParams - Params to be used on the request. If none passed, it will default to page's size 25 and the current catalog version
+ * @param method - String with the type of API call, must be either GET or POST for now
  * @returns @see ListResponseType
  */
 export const listAll = async (
   apiPath: string,
-  listParams?: AzulListParams
+  listParams?: AzulListParams,
+  method?: ApiOption
 ): Promise<AzulEntitiesResponse> => {
   let hits = [];
-  const result = await list(apiPath, listParams);
+  const result = await list(apiPath, listParams, method);
   hits = result.hits;
   let nextPage = result.pagination.next;
   while (nextPage) {
@@ -75,17 +84,20 @@ export const listAll = async (
  *  Request to get a single project.
  * @param id - project's uuid.
  * @param apiPath - API endpoint URL.
+ * @param method - The method to use to make the API call, right now either GET or POST
  * @param param - Catalog's version, if none passed it will default to the current one.
  * @returns @see ProjectResponse
  */
 export const detail = async (
   id: string,
   apiPath: string,
+  method?: ApiOption,
   param = DEFAULT_DETAIL_PARAMS
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- this response type can't be determined beforehand
 ): Promise<any> => {
   const res = await fetch(
-    `${URL}${apiPath}/${id}?${convertUrlParams({ ...param })}`
+    `${URL}${apiPath}/${id}?${convertUrlParams({ ...param })}`,
+    { method: method }
   );
   return await res.json();
 };

--- a/explorer/app/entity/fetcher/model.ts
+++ b/explorer/app/entity/fetcher/model.ts
@@ -3,6 +3,7 @@ import {
   AzulListParams,
   AzulSummaryResponse,
 } from "../../apis/azul/common/entities";
+import { ApiOption } from "../../config/common/entities";
 
 /**
  * Object that has all necessary functions to fetch data to fill listing and detail pages
@@ -12,17 +13,20 @@ export interface Fetcher {
   detail: (
     id: string,
     apiPath: string,
+    method?: ApiOption,
     param?: { [key: string]: string }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- This type can't be known before hand
   ) => Promise<any>;
-  fetchList: (url: string) => Promise<AzulEntitiesResponse>;
+  fetchList: (url: string, method?: ApiOption) => Promise<AzulEntitiesResponse>;
   list: (
     apiPath: string,
-    listParams?: AzulListParams
+    listParams?: AzulListParams,
+    method?: ApiOption
   ) => Promise<AzulEntitiesResponse>;
   listAll: (
     apiPath: string,
-    listParams?: AzulListParams
+    listParams?: AzulListParams,
+    method?: ApiOption
   ) => Promise<AzulEntitiesResponse>;
   summary: (
     apiPath: string,

--- a/explorer/app/entity/fetcher/model.ts
+++ b/explorer/app/entity/fetcher/model.ts
@@ -3,7 +3,7 @@ import {
   AzulListParams,
   AzulSummaryResponse,
 } from "../../apis/azul/common/entities";
-import { ApiOption } from "../../config/common/entities";
+import { Options } from "../../config/common/entities";
 
 /**
  * Object that has all necessary functions to fetch data to fill listing and detail pages
@@ -13,20 +13,20 @@ export interface Fetcher {
   detail: (
     id: string,
     apiPath: string,
-    method?: ApiOption,
+    options?: Options,
     param?: { [key: string]: string }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- This type can't be known before hand
   ) => Promise<any>;
-  fetchList: (url: string, method?: ApiOption) => Promise<AzulEntitiesResponse>;
+  fetchList: (url: string, options?: Options) => Promise<AzulEntitiesResponse>;
   list: (
     apiPath: string,
     listParams?: AzulListParams,
-    method?: ApiOption
+    options?: Options
   ) => Promise<AzulEntitiesResponse>;
   listAll: (
     apiPath: string,
     listParams?: AzulListParams,
-    method?: ApiOption
+    options?: Options
   ) => Promise<AzulEntitiesResponse>;
   summary: (
     apiPath: string,

--- a/explorer/app/entity/fetcher/model.ts
+++ b/explorer/app/entity/fetcher/model.ts
@@ -17,7 +17,11 @@ export interface Fetcher {
     param?: { [key: string]: string }
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- This type can't be known before hand
   ) => Promise<any>;
-  fetchList: (url: string, options?: Options) => Promise<AzulEntitiesResponse>;
+  fetchList: (
+    url: string,
+    params?: Record<string, string>,
+    options?: Options
+  ) => Promise<AzulEntitiesResponse>;
   list: (
     apiPath: string,
     listParams?: AzulListParams,

--- a/explorer/app/hooks/useFetchEntities.ts
+++ b/explorer/app/hooks/useFetchEntities.ts
@@ -50,7 +50,7 @@ export const useFetchEntities = (
   staticResponse: AzulEntitiesStaticResponse | null
 ): EntitiesResponse => {
   // Determine type of fetch to be executed, either API endpoint or TSV.
-  const { list, path, staticLoad } = useFetcher();
+  const { list, method, path, staticLoad } = useFetcher();
 
   // Init fetch of entities.
   const { data, isIdle, isLoading, run } = useAsync<AzulEntitiesResponse>();
@@ -93,9 +93,9 @@ export const useFetchEntities = (
       }
 
       // Execute the fetch.
-      run(list(path, listParams));
+      run(list(path, listParams, method));
     }
-  }, [filterState, list, path, run, sortKey, sortOrder, staticLoad]);
+  }, [filterState, list, method, path, run, sortKey, sortOrder, staticLoad]);
 
   const handleFilterChange = useCallback(
     (

--- a/explorer/app/hooks/useFetchEntities.ts
+++ b/explorer/app/hooks/useFetchEntities.ts
@@ -50,7 +50,7 @@ export const useFetchEntities = (
   staticResponse: AzulEntitiesStaticResponse | null
 ): EntitiesResponse => {
   // Determine type of fetch to be executed, either API endpoint or TSV.
-  const { list, method, path, staticLoad } = useFetcher();
+  const { list, options, path, staticLoad } = useFetcher();
 
   // Init fetch of entities.
   const { data, isIdle, isLoading, run } = useAsync<AzulEntitiesResponse>();
@@ -93,9 +93,9 @@ export const useFetchEntities = (
       }
 
       // Execute the fetch.
-      run(list(path, listParams, method));
+      run(list(path, listParams, options));
     }
-  }, [filterState, list, method, path, run, sortKey, sortOrder, staticLoad]);
+  }, [filterState, list, options, path, run, sortKey, sortOrder, staticLoad]);
 
   const handleFilterChange = useCallback(
     (

--- a/explorer/app/hooks/useFetchEntity.tsx
+++ b/explorer/app/hooks/useFetchEntity.tsx
@@ -19,7 +19,7 @@ interface UseEntityDetailResponse<T> {
 export const useFetchEntity = <T,>(
   value?: AzulEntityStaticResponse
 ): UseEntityDetailResponse<T> => {
-  const { detail, path, staticLoad } = useFetcher();
+  const { detail, method, path, staticLoad } = useFetcher();
   const router = useRouter();
   const uuid = router.query.params?.[PARAMS_INDEX_UUID] as string;
   const {
@@ -31,9 +31,9 @@ export const useFetchEntity = <T,>(
 
   useEffect(() => {
     if (!staticLoad && uuid) {
-      run(detail(uuid, path));
+      run(detail(uuid, path, method));
     }
-  }, [detail, path, run, staticLoad, uuid]);
+  }, [detail, path, run, staticLoad, uuid, method]);
 
   if (staticLoad) {
     return { isLoading: false, response: value?.data };

--- a/explorer/app/hooks/useFetchEntity.tsx
+++ b/explorer/app/hooks/useFetchEntity.tsx
@@ -19,7 +19,7 @@ interface UseEntityDetailResponse<T> {
 export const useFetchEntity = <T,>(
   value?: AzulEntityStaticResponse
 ): UseEntityDetailResponse<T> => {
-  const { detail, method, path, staticLoad } = useFetcher();
+  const { detail, options, path, staticLoad } = useFetcher();
   const router = useRouter();
   const uuid = router.query.params?.[PARAMS_INDEX_UUID] as string;
   const {
@@ -31,9 +31,9 @@ export const useFetchEntity = <T,>(
 
   useEffect(() => {
     if (!staticLoad && uuid) {
-      run(detail(uuid, path, method));
+      run(detail(uuid, path, options));
     }
-  }, [detail, path, run, staticLoad, uuid, method]);
+  }, [detail, path, run, staticLoad, uuid, options]);
 
   if (staticLoad) {
     return { isLoading: false, response: value?.data };

--- a/explorer/app/hooks/useFetcher.ts
+++ b/explorer/app/hooks/useFetcher.ts
@@ -1,9 +1,10 @@
-import { EntityConfig } from "../config/common/entities";
+import { ApiOption, EntityConfig } from "../config/common/entities";
 import { create } from "../entity/fetcher/factory";
 import { Fetcher } from "../entity/fetcher/model";
 import { useCurrentEntity } from "./useCurrentEntity";
 
 interface FetcherResponse extends Fetcher {
+  method?: ApiOption;
   path: string;
   staticLoad: boolean;
 }
@@ -12,6 +13,7 @@ export const getFetcher = (entity: EntityConfig): FetcherResponse => {
   if (entity.apiPath) {
     return {
       ...create("API"),
+      method: entity.options?.method,
       path: entity.apiPath,
       staticLoad: !!entity.staticLoad,
     };

--- a/explorer/app/hooks/useFetcher.ts
+++ b/explorer/app/hooks/useFetcher.ts
@@ -1,10 +1,10 @@
-import { ApiOption, EntityConfig } from "../config/common/entities";
+import { EntityConfig, Options } from "../config/common/entities";
 import { create } from "../entity/fetcher/factory";
 import { Fetcher } from "../entity/fetcher/model";
 import { useCurrentEntity } from "./useCurrentEntity";
 
 interface FetcherResponse extends Fetcher {
-  method?: ApiOption;
+  options?: Options;
   path: string;
   staticLoad: boolean;
 }
@@ -13,7 +13,7 @@ export const getFetcher = (entity: EntityConfig): FetcherResponse => {
   if (entity.apiPath) {
     return {
       ...create("API"),
-      method: entity.options?.method,
+      options: entity.options,
       path: entity.apiPath,
       staticLoad: !!entity.staticLoad,
     };

--- a/explorer/site-config/ncpi-catalog-dug/dev/index/relatedStudiesEntityConfig.ts
+++ b/explorer/site-config/ncpi-catalog-dug/dev/index/relatedStudiesEntityConfig.ts
@@ -28,5 +28,6 @@ export const relatedStudiesEntityConfig: EntityConfig<DugVariableResponse> = {
       },
     ],
   } as ListConfig<DugVariableResponse>,
+  options: { method: "POST" },
   route: "related",
 };


### PR DESCRIPTION
### Ticket
Closes #525 .

### Reviewers
@MillenniumFalconMechanic .

### Changes
- Set `fetchList` and associated functions and objects to store an Objects interface with options for the request
- Set the `ncpi-catalog-dug` configuration to make a POST request

### Definition of Done (from ticket)
- Clicking on the "Related Studies" tab sends a POST request to the Dug API endpoint.
- All Azul-related endpoints continue to use GET requests.

### Known Issues
- Still nothing renders on the `ncpi-catalog-dug` "Related Studies" page
- Test code needs to be removed before merging
