### PR TITLE
Fix switching tabs #523

### DIFF
--- a/explorer/app/components/Table/table.tsx
+++ b/explorer/app/components/Table/table.tsx
@@ -34,6 +34,8 @@ export interface EditColumnConfig {
 interface TableProps<T extends object> {
   columns: ColumnDef<T>[];
   count?: number;
+  currentEntityRoute: string;
+  dataEntityRoute: string;
   disablePagination?: boolean;
   editColumns?: EditColumnConfig;
   gridTemplateColumns: string;
@@ -43,7 +45,6 @@ interface TableProps<T extends object> {
   pageSize: number;
   pagination?: Pagination;
   sort?: Sort;
-  staticallyLoaded?: boolean;
   total?: number;
 }
 
@@ -240,22 +241,11 @@ const shouldSkipRender = <T extends object>(
   nextProps: TableProps<T>
 ): boolean => {
   /**
-   * If the table's items aren't statically loaded, skip the next render when the component
-   * is loading
-   */
-  if (!nextProps.staticallyLoaded) {
-    return !!nextProps.loading;
-  }
-
-  /**
-   * If the table's items are statically loaded, check if both columns config and items
-   * have changed. If not, skip the next render
+   * Skip the next render when component is loading or if data route is different from the current one
    */
   return (
-    (prevProps.columns !== nextProps.columns &&
-      prevProps.items === nextProps.items) ||
-    (prevProps.columns === nextProps.columns &&
-      prevProps.items !== nextProps.items)
+    !!nextProps.loading ||
+    nextProps.currentEntityRoute !== nextProps.dataEntityRoute
   );
 };
 

--- a/explorer/app/components/TableCreator/tableCreator.tsx
+++ b/explorer/app/components/TableCreator/tableCreator.tsx
@@ -13,6 +13,8 @@ import { Table } from "../Table/table";
 
 interface TableCreatorProps<T> {
   columns: ColumnConfig<T>[];
+  currentEntityRoute: string;
+  dataEntityRoute: string;
   disablePagination?: boolean;
   items: T[];
   loading?: boolean;
@@ -21,7 +23,6 @@ interface TableCreatorProps<T> {
   pageSize: number;
   pagination?: Pagination;
   sort?: Sort;
-  staticallyLoaded?: boolean;
   total?: number;
 }
 
@@ -66,6 +67,8 @@ const createCell = <T extends object>(config: ColumnConfig<T>) =>
 
 export const TableCreator = <T extends object>({
   columns,
+  currentEntityRoute,
+  dataEntityRoute,
   disablePagination,
   items,
   loading,
@@ -74,7 +77,6 @@ export const TableCreator = <T extends object>({
   pageSize,
   pagination,
   sort,
-  staticallyLoaded,
   total,
 }: TableCreatorProps<T>): JSX.Element => {
   const { editColumns, visibleColumns } = useEditColumns(columns);
@@ -107,7 +109,8 @@ export const TableCreator = <T extends object>({
         total={total}
         count={pageCount}
         loading={loading}
-        staticallyLoaded={staticallyLoaded}
+        currentEntityRoute={currentEntityRoute}
+        dataEntityRoute={dataEntityRoute}
       />
     </div>
   );

--- a/explorer/app/entity/api/service.ts
+++ b/explorer/app/entity/api/service.ts
@@ -18,12 +18,18 @@ import { convertUrlParams } from "../../utils/url";
  * Request to get a list of entities.
  * @param apiPath - Path that will be used to compose the API url
  * @param listParams - Params to be used on the request. If none passed, it will default to page's size 25 and the current catalog version
+ * @param staticResponse - Param to determine that the response was loaded statically and should be returned as promise result.
  * @returns @see ListResponseType
  */
 export const list = async (
   apiPath: string,
-  listParams?: AzulListParams
+  listParams?: AzulListParams,
+  staticResponse?: AzulEntitiesResponse
 ): Promise<AzulEntitiesResponse> => {
+  if (staticResponse) {
+    return new Promise((resolve) => resolve(staticResponse));
+  }
+
   const params = { ...DEFAULT_LIST_PARAMS, ...listParams };
   return await fetchList(`${URL}${apiPath}?${convertUrlParams(params)}`);
 };

--- a/explorer/app/entity/fetcher/model.ts
+++ b/explorer/app/entity/fetcher/model.ts
@@ -18,7 +18,8 @@ export interface Fetcher {
   fetchList: (url: string) => Promise<AzulEntitiesResponse>;
   list: (
     apiPath: string,
-    listParams?: AzulListParams
+    listParams?: AzulListParams,
+    staticResponse?: AzulEntitiesResponse
   ) => Promise<AzulEntitiesResponse>;
   listAll: (
     apiPath: string,

--- a/explorer/app/hooks/usePagination.ts
+++ b/explorer/app/hooks/usePagination.ts
@@ -1,14 +1,14 @@
 import { AzulEntitiesResponse } from "app/apis/azul/common/entities";
 import { Pagination } from "app/common/entities";
 import { useCallback, useState } from "react";
-import { useAsync } from "./useAsync";
 import { useFetcher } from "./useFetcher";
 
 const DEFAULT_CURRENT_PAGE = 1;
 
-export const usePagination = (data?: AzulEntitiesResponse): Pagination => {
-  const { run } = useAsync<AzulEntitiesResponse>();
-
+export const usePagination = (
+  runFn: (p: Promise<AzulEntitiesResponse>) => Promise<AzulEntitiesResponse>,
+  data?: AzulEntitiesResponse
+): Pagination => {
   // Determine type of fetch to be executed, either API endpoint or TSV.
   const { fetchList } = useFetcher();
 
@@ -19,17 +19,17 @@ export const usePagination = (data?: AzulEntitiesResponse): Pagination => {
   const nextPage = useCallback(async () => {
     if (data?.pagination.next) {
       setCurrentPage((s) => s + 1);
-      run(fetchList(data.pagination.next));
+      runFn(fetchList(data.pagination.next));
     }
-  }, [data?.pagination.next, fetchList, run]);
+  }, [data?.pagination.next, fetchList, runFn]);
 
   // Create callback for previous page action.
   const previousPage = useCallback(async () => {
     if (data?.pagination.previous) {
       setCurrentPage((s) => s - 1);
-      run(fetchList(data.pagination.previous));
+      runFn(fetchList(data.pagination.previous));
     }
-  }, [data?.pagination.previous, fetchList, run]);
+  }, [data?.pagination.previous, fetchList, runFn]);
 
   const resetPage = useCallback(() => {
     setCurrentPage(DEFAULT_CURRENT_PAGE);

--- a/explorer/app/views/Index/index.tsx
+++ b/explorer/app/views/Index/index.tsx
@@ -70,7 +70,7 @@ export const Index = (props: AzulEntitiesStaticResponse): JSX.Element => {
   const entity = useCurrentEntity();
   const { entities, entityTitle, summaryConfig } = useConfig();
 
-  const route = entity?.route;
+  const route = entity.route;
   const { push } = useRouter();
 
   // Init tabs state.
@@ -79,11 +79,19 @@ export const Index = (props: AzulEntitiesStaticResponse): JSX.Element => {
 
   // Fetch summary and entities.
   const { response: summaryResponse } = useSummary();
-  const { categories, loading, onFilter, pagination, response, sort } =
-    useFetchEntities(props);
+  const {
+    categories,
+    dataEntity,
+    dataEntityRoute,
+    loading,
+    onFilter,
+    pagination,
+    response,
+    sort,
+  } = useFetchEntities(props);
 
   // Grab the column config for the current entity.
-  const columnsConfig = entity?.list?.columns;
+  const columnsConfig = dataEntity.list.columns;
 
   /**
    * Callback fired when selected tab value changes.
@@ -142,8 +150,9 @@ export const Index = (props: AzulEntitiesStaticResponse): JSX.Element => {
         sort={sort}
         pages={entitiesResponse.pagination.pages}
         loading={loading}
-        staticallyLoaded={entity.staticLoad}
         disablePagination={config.disablePagination}
+        currentEntityRoute={route}
+        dataEntityRoute={dataEntityRoute}
       />
     );
   };


### PR DESCRIPTION
### Ticket
Closes #523

### Reviewers
@.

### Changes
- Syncing state changes with the entity which made the request

### Definition of Done (from ticket)

### QA steps (optional)

### Known Issues
TL;DR: The state management of the application is getting complex. I think the app would beneficiate a lot from the use of redux.
A lot of components are kept mounted on the listing page when tabs change (`Index`, `TableCreator`, `Table`, `ComponentCreator`) and almost all of these components have dependencies of the current entity and the request's response, but if they change out of sync we get errors like the one described on the issue. 


