### PR TITLE
538 npm run test is running e2e tests

### DIFF
--- a/explorer/jest.config.js
+++ b/explorer/jest.config.js
@@ -15,6 +15,7 @@ const customJestConfig = {
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
   moduleDirectories: ["node_modules", "<rootDir>/"],
   testEnvironment: "jest-environment-jsdom",
+  testPathIgnorePatterns: ["/node_modules/", "/e2e/"],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -23,7 +23,7 @@
     "prepare": "cd .. && husky install explorer/.husky",
     "storybook": "start-storybook -s images,.next  -p 6006",
     "build-storybook": "build-storybook",
-    "test": "jest --watch ./__tests__/*",
+    "test": "jest --watch",
     "test:e2e": "playwright test ./e2e/*"
   },
   "dependencies": {

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -24,7 +24,7 @@
     "storybook": "start-storybook -s images,.next  -p 6006",
     "build-storybook": "build-storybook",
     "test": "jest --watch",
-    "test:e2e": "playwright test ./e2e/*"
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@emotion/react": "^11.9.0",

--- a/explorer/playwright.config.ts
+++ b/explorer/playwright.config.ts
@@ -1,0 +1,5 @@
+import type { PlaywrightTestConfig } from "@playwright/test";
+const config: PlaywrightTestConfig = {
+  testDir: "e2e",
+};
+export default config;


### PR DESCRIPTION
### Ticket
Closes #538 .

### Reviewers
@NoopDog .

### Changes
- Set Jest and Playwright to only run tests from the correct folder
