### PR TITLE
Create button widget for showing "views" of the entity list (e.g. Exact Match/Related). #618.

### DIFF
--- a/explorer/app/components/Table/table.tsx
+++ b/explorer/app/components/Table/table.tsx
@@ -16,6 +16,7 @@ import {
   getPaginationRowModel,
   useReactTable,
 } from "@tanstack/react-table";
+import { ListViewConfig } from "app/config/common/entities";
 import { useScroll } from "app/hooks/useScroll";
 import React, { useContext, useEffect } from "react";
 import {
@@ -25,6 +26,7 @@ import {
 import { Pagination, Sort, SortOrderType } from "../../common/entities";
 import { CheckboxMenu, CheckboxMenuItem } from "../CheckboxMenu/checkboxMenu";
 import { GridPaper, RoundedPaper } from "../common/Paper/paper.styles";
+import { ToggleButtonGroup } from "../common/ToggleButtonGroup/toggleButtonGroup";
 import {
   buildCategoryViews,
   getFacetedUniqueValuesWithArrayValues,
@@ -47,6 +49,7 @@ interface TableProps<T extends object> {
   editColumns?: EditColumnConfig;
   gridTemplateColumns: string;
   items: T[];
+  listView?: ListViewConfig;
   loading?: boolean;
   pages?: number;
   pageSize: number;
@@ -64,6 +67,7 @@ interface TableProps<T extends object> {
  * @param tableProps.items - Row data to display.
  * @param tableProps.columns - Set of columns to display.
  * @param tableProps.editColumns - True if edit column functionality is enabled for table.
+ * @param tableProps.listView - Entity list toggle button for switching between "views".
  * @param tableProps.total - Total number of rows in the result set.
  * @param tableProps.sort - Config for rendering current sort and handling corresponding events.
  * @param tableProps.gridTemplateColumns - Defines grid table track sizing.
@@ -76,6 +80,7 @@ export const TableComponent = <T extends object>({
   editColumns,
   gridTemplateColumns,
   items,
+  listView,
   sort,
   total,
 }: TableProps<T>): JSX.Element => {
@@ -244,11 +249,15 @@ export const TableComponent = <T extends object>({
       <GridPaper>
         {editColumns && (
           <TableToolbar>
-            <PaginationSummary
-              firstResult={(currentPage - 1) * pageSize + 1}
-              lastResult={isLastPage ? rows : pageSize * currentPage}
-              totalResult={rows}
-            />
+            {listView ? (
+              <ToggleButtonGroup toggleButtons={listView.toggleButtons} />
+            ) : (
+              <PaginationSummary
+                firstResult={(currentPage - 1) * pageSize + 1}
+                lastResult={isLastPage ? rows : pageSize * currentPage}
+                totalResult={rows}
+              />
+            )}
             <CheckboxMenu
               label="Edit Columns"
               onItemSelectionChange={editColumns.onVisibleColumnsChange}

--- a/explorer/app/components/TableCreator/tableCreator.tsx
+++ b/explorer/app/components/TableCreator/tableCreator.tsx
@@ -3,6 +3,7 @@ import {
   ColumnConfig,
   GridTrackMinMax,
   GridTrackSize,
+  ListViewConfig,
 } from "app/config/common/entities";
 import { useEditColumns } from "app/hooks/useEditColumns";
 import React, { useMemo } from "react";
@@ -18,6 +19,7 @@ interface TableCreatorProps<T> {
   disablePagination?: boolean;
   exploreState: ExploreState;
   items: T[];
+  listView?: ListViewConfig;
   loading?: boolean;
   pageCount?: number;
   pages: number;
@@ -71,6 +73,7 @@ export const TableCreator = <T extends object>({
   columns,
   disablePagination,
   items,
+  listView,
   loading,
   pageCount,
   pages,
@@ -105,6 +108,7 @@ export const TableCreator = <T extends object>({
         editColumns={editColumns}
         gridTemplateColumns={gridTemplateColumns}
         items={items}
+        listView={listView}
         pages={pages}
         pageSize={pageSize}
         pagination={pagination}

--- a/explorer/app/components/common/ToggleButtonGroup/toggleButtonGroup.stories.tsx
+++ b/explorer/app/components/common/ToggleButtonGroup/toggleButtonGroup.stories.tsx
@@ -1,0 +1,38 @@
+import { ComponentMeta, ComponentStory } from "@storybook/react";
+import React from "react";
+import { ToggleButtonGroup } from "./toggleButtonGroup";
+
+export default {
+  argTypes: {
+    toggleButtons: { table: { disable: true } },
+  },
+  component: ToggleButtonGroup,
+  parameters: {
+    layout: "centered",
+  },
+  title: "Components/Common/ButtonGroup",
+} as ComponentMeta<typeof ToggleButtonGroup>;
+
+const PrimaryTemplate: ComponentStory<typeof ToggleButtonGroup> = (args) => (
+  <ToggleButtonGroup {...args} />
+);
+
+export const PrimaryToggleButtonGroup = PrimaryTemplate.bind({});
+PrimaryToggleButtonGroup.args = {
+  toggleButtons: [
+    {
+      label: "Exact Match (243)",
+      onToggle: (): void => {
+        // onToggle function
+      },
+      value: "exact-match",
+    },
+    {
+      label: "Related (33)",
+      onToggle: (): void => {
+        // onToggle function
+      },
+      value: "related-match",
+    },
+  ],
+};

--- a/explorer/app/components/common/ToggleButtonGroup/toggleButtonGroup.tsx
+++ b/explorer/app/components/common/ToggleButtonGroup/toggleButtonGroup.tsx
@@ -1,0 +1,86 @@
+/**
+ * An extension of the basic Mui ButtonGroup component with available ButtonGroup props.
+ */
+import {
+  ToggleButton as MToggleButton,
+  ToggleButtonGroup as MToggleButtonGroup,
+  ToggleButtonGroupProps,
+  ToggleButtonProps,
+} from "@mui/material";
+import React, { MouseEvent, useState } from "react";
+
+export type OnToggleButtonFn = () => void; // Function invoked when selected toggle button value changes.
+type ToggleButtonValue = ToggleButtonProps["value"];
+type ToggleButtonGroupValue = ToggleButtonGroupProps["value"];
+
+export interface ToggleButton {
+  label: string;
+  onToggle: OnToggleButtonFn;
+  value: ToggleButtonValue;
+}
+
+interface Props {
+  toggleButtons: ToggleButton[];
+}
+
+/**
+ * Returns the selected toggle button action.
+ * @param toggleButtons - Toggle buttons.
+ * @param toggleValue - Selected value within the group.
+ * @returns the selected toggle button action.
+ */
+function getSelectedToggleButtonAction(
+  toggleButtons: ToggleButton[],
+  toggleValue: ToggleButtonGroupValue
+): OnToggleButtonFn | undefined {
+  return toggleButtons.find(({ value }) => value === toggleValue)?.onToggle;
+}
+
+export const ToggleButtonGroup = ({
+  toggleButtons,
+  ...props
+}: Props): JSX.Element => {
+  const [toggleValue, setToggleValue] = useState<ToggleButtonGroupValue>(
+    toggleButtons[0]?.value
+  );
+
+  /**
+   * Callback fired when toggle button value changes.
+   * - Sets state toggleValue to selected value.
+   * - Executes onToggle action as defined by selected toggle button.
+   * @param mouseEvent - The event source of the callback.
+   * @param newToggleValue - The value of the selected toggle button.
+   * @param onToggleFn - The selected toggle button action.
+   */
+  const onChangeToggleButton = (
+    mouseEvent: MouseEvent<HTMLElement>,
+    newToggleValue: ToggleButtonGroupValue,
+    onToggleFn: OnToggleButtonFn | undefined
+  ): void => {
+    if (newToggleValue) {
+      setToggleValue(newToggleValue);
+      onToggleFn && onToggleFn();
+    }
+  };
+
+  return (
+    <MToggleButtonGroup
+      exclusive
+      onChange={(e, value): void =>
+        onChangeToggleButton(
+          e,
+          value,
+          getSelectedToggleButtonAction(toggleButtons, value)
+        )
+      }
+      value={toggleValue}
+      {...props}
+    >
+      {toggleButtons.map(({ label, value }) => (
+        <MToggleButton key={label} value={value}>
+          {label}
+        </MToggleButton>
+      ))}
+    </MToggleButtonGroup>
+  );
+};

--- a/explorer/app/config/common/entities.ts
+++ b/explorer/app/config/common/entities.ts
@@ -3,6 +3,7 @@ import { Footer, Header } from "app/components/Layout/common/entities";
 import { JSXElementConstructor } from "react";
 import { ExploreState } from "../../common/context/exploreState";
 import { HeroTitle } from "../../components/common/Title/title";
+import { ToggleButton } from "../../components/common/ToggleButtonGroup/toggleButtonGroup";
 
 type GetIdFunction<T> = (detail: T) => string;
 type EntityImportMapper<I, D> = (input: I) => D;
@@ -33,6 +34,7 @@ export interface EntityConfig<D = any, I = any> extends TabConfig {
   detail: BackPageConfig;
   getId?: GetIdFunction<D>;
   list: ListConfig;
+  listView?: ListViewConfig;
   options?: Options;
   staticEntityImportMapper?: EntityImportMapper<I, D>;
   staticLoad: boolean;
@@ -124,6 +126,13 @@ export interface ColumnConfig<
   };
   tooltip?: string;
   width: GridTrackSize;
+}
+
+/**
+ * Interface to define the entity list toggle button for switching between "views".
+ */
+export interface ListViewConfig {
+  toggleButtons: ToggleButton[];
 }
 
 export interface GoogleGISAuthConfig {

--- a/explorer/app/theme/theme.ts
+++ b/explorer/app/theme/theme.ts
@@ -215,6 +215,7 @@ export const getAppTheme = (customTheme?: ThemeOptions): Theme => {
   const smoke = defaultTheme.palette.smoke.main;
   const smokeDark = defaultTheme.palette.smoke.dark;
   const smokeLight = defaultTheme.palette.smoke.light;
+  const smokeLightest = defaultTheme.palette.smoke.lightest;
   const warningLight = defaultTheme.palette.warning.light;
   const white = defaultTheme.palette.common.white;
 
@@ -835,6 +836,49 @@ export const getAppTheme = (customTheme?: ThemeOptions): Theme => {
             [breakpointUpTablet]: {
               margin: 0,
             },
+          },
+        },
+      },
+      MuiToggleButton: {
+        styleOverrides: {
+          root: {
+            ...textBody500,
+            backgroundColor: smoke,
+            border: "none",
+            borderRadius: 4,
+            color: ink,
+            flex: 1,
+            padding: "8px 12px",
+            // eslint-disable-next-line sort-keys -- disabling key order for readability
+            "&:hover": {
+              backgroundColor: smokeLightest,
+            },
+            // eslint-disable-next-line sort-keys -- disabling key order for readability
+            "&.Mui-selected": {
+              backgroundColor: white,
+              // eslint-disable-next-line sort-keys -- disabling key order for readability
+              "&:hover": {
+                backgroundColor: white,
+              },
+            },
+          },
+        },
+      },
+      MuiToggleButtonGroup: {
+        styleOverrides: {
+          grouped: {
+            border: "none !important", // Overrides "grouped" css selector specificity.
+            borderRadius: "4px !important", // Overrides "grouped" css selector specificity.
+            margin: "0 !important", // Overrides "grouped" css selector specificity.
+          },
+          root: {
+            backgroundColor: smoke,
+            borderRadius: 6,
+            color: ink,
+            display: "grid",
+            gridAutoColumns: "1fr",
+            gridAutoFlow: "column",
+            padding: 2,
           },
         },
       },

--- a/explorer/app/views/ExploreView/exploreView.tsx
+++ b/explorer/app/views/ExploreView/exploreView.tsx
@@ -33,7 +33,7 @@ export const ExploreView = (props: AzulEntitiesStaticResponse): JSX.Element => {
 
   const { categoryViews, sortState, tabValue } = exploreState;
   const { push } = useRouter();
-  const { list, staticLoad } = getEntityConfig(tabValue);
+  const { list, listView, staticLoad } = getEntityConfig(tabValue);
 
   const { columns: columnsConfig } = list;
   const tabs = getTabs();
@@ -130,6 +130,7 @@ export const ExploreView = (props: AzulEntitiesStaticResponse): JSX.Element => {
         columns={columnsConfig}
         exploreState={exploreState}
         items={exploreState.listItems ?? []}
+        listView={listView}
         pageSize={exploreState.paginationState.pageSize}
         total={exploreState.paginationState.rows}
         pagination={undefined}

--- a/explorer/site-config/ncpi-catalog-dug/dev/config.ts
+++ b/explorer/site-config/ncpi-catalog-dug/dev/config.ts
@@ -10,7 +10,26 @@ const config: SiteConfig = {
     defaultListParams: DUG_API_PARAMS,
     url: DUG_API_URL,
   },
-  entities: [studiesEntityConfig /*relatedStudiesEntity*/],
+  entities: [
+    {
+      ...studiesEntityConfig,
+      listView: {
+        // TODO list view configuration
+        toggleButtons: [
+          {
+            label: "Exact Match (243)",
+            onToggle: () => console.log("exact-match"),
+            value: "NCPI",
+          },
+          {
+            label: "Related (33)",
+            onToggle: () => console.log("related-match"),
+            value: "AnVIL",
+          },
+        ],
+      },
+    } /*relatedStudiesEntity*/,
+  ],
   layout: {
     ...ncpiDevConfig.layout,
     header: {


### PR DESCRIPTION
### Ticket
Closes #618.

### Reviewers
@NoopDog.

### Changes
- Added button widget `ToggleButtonGroup` to facilitate switching "views" of the entity list.
- Added placeholder config in `explorer/site-config/ncpi-catalog-dug/dev/config.ts` for display of widget on DUG.

### Definition of Done (from ticket)
- Added button widget to facilitate switching of "views" of the entity list.