### PR TITLE
Download  column is showing up as an empty checkbox in the "Edit Columns" menu for files tabs. #647.

### DIFF
--- a/explorer/app/config/common/entities.ts
+++ b/explorer/app/config/common/entities.ts
@@ -124,8 +124,9 @@ export interface ColumnConfig<
   C extends keyof JSX.IntrinsicElements | JSXElementConstructor<any> = any
 > {
   componentConfig: ComponentConfig<C, T>;
+  editable?: boolean; // Determines editability of column via "Edit Columns" functionality (default is "true").
   header: string;
-  hiddenColumn?: boolean; //TODO rename to hidded by default or similar
+  hiddenColumn?: boolean; //TODO rename to hidden by default or similar
   sort: {
     default?: boolean;
     sortKey: string;

--- a/explorer/app/hooks/useEditColumns.ts
+++ b/explorer/app/hooks/useEditColumns.ts
@@ -18,10 +18,12 @@ export const useEditColumns = (columns: ColumnConfig[]) => {
 
   const readOnlyColumns = defaultColumns.map(({ header }) => header);
   const selectedColumns = visibleColumns.map(({ header }) => header);
-  const columnsOptions = columns.map(({ header }) => ({
-    id: header,
-    label: header,
-  }));
+  const columnsOptions = columns
+    .filter(({ editable = true }) => editable) // Default is to show all columns, unless the column config "editable" is specified otherwise.
+    .map(({ header }) => ({
+      id: header,
+      label: header,
+    }));
 
   const handleVisibleColumnsChanged = useCallback(
     (columnId: string) => {

--- a/explorer/site-config/hca-dcp/dev/index/filesEntityConfig.ts
+++ b/explorer/site-config/hca-dcp/dev/index/filesEntityConfig.ts
@@ -36,6 +36,7 @@ export const filesEntityConfig: EntityConfig<FilesResponse> = {
           component: Components.AzulFileDownload,
           viewBuilder: filesBuildFileDownload,
         } as ComponentConfig<typeof Components.AzulFileDownload>,
+        editable: false,
         header: " ",
         width: "auto",
       },


### PR DESCRIPTION
### Ticket
Closes #647 

### Reviewers
@NoopDog 

### Changes
- Modified column config and useEditColumns hook to only show editable columns in the "Edit Columns" menu.

### Definition of Done (from ticket)
- Columns that should not be included in the "Edit Columns" menu are excluded from the available list of editable columns.