### PR TITLE
feat: make doi on experiments column off by default (#18)

### DIFF
--- a/explorer/site-config/altos-labs-catalog/dev/index/experimentEntityConfig.ts
+++ b/explorer/site-config/altos-labs-catalog/dev/index/experimentEntityConfig.ts
@@ -78,6 +78,7 @@ export const experimentEntity: EntityConfig<AltosLabsCatalogExperiment> = {
           viewBuilder: ViewBuilder.buildDOI,
         } as ComponentConfig<typeof Components.Link>,
         header: "DOI",
+        hiddenColumn: true,
         sort: {
           default: true,
           sortKey: ALTOS_LABS_CATALOG_FILTER_CATEGORY_KEYS.DOI,


### PR DESCRIPTION
### Ticket
Closes https://github.com/clevercanary/altos-data-browser/issues/18.

### Reviewers
@NoopDog 

### Changes
- Modified DOI on experiment entity list to be hidden by default.

### Definition of Done (from ticket)
- DOI is hidden by default on experiment entity list.
