### PR TITLE
feat: add "experiment" to filters using the title (#19)

### DIFF
--- a/explorer/app/viewModelBuilders/catalog/altos-labs-catalog/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/catalog/altos-labs-catalog/common/viewModelBuilders.ts
@@ -52,6 +52,21 @@ export const buildDOI = (
 };
 
 /**
+ * Build props for experiment cell component from the given Altos Labs entity.
+ * @param altosLabsCatalogEntity - Altos Labs catalog entity.
+ * @returns Model to be used as props for the experiment cell.
+ */
+export const buildExperiment = (
+  altosLabsCatalogEntity: AltosLabsCatalogEntity
+): React.ComponentProps<typeof C.Link> => {
+  const { shorthand, title } = altosLabsCatalogEntity;
+  return {
+    label: title,
+    url: shorthand ? `/experiments/${shorthand}` : "",
+  };
+};
+
+/**
  * Build props for MdxMarkdown component from the given Altos Labs entity.
  * @param altosLabsCatalogEntity - Altos Labs catalog entity.
  * @returns Model to be used as props for the MdxMarkdown component.
@@ -216,21 +231,6 @@ export const buildTissue = (
   return {
     label: getPluralizedMetadataLabel(METADATA_KEY.TISSUE),
     values: altosLabsCatalogEntity.tissue,
-  };
-};
-
-/**
- * Build props for title cell component from the given Altos Labs entity.
- * @param altosLabsCatalogEntity - Altos Labs catalog entity.
- * @returns Model to be used as props for the title cell.
- */
-export const buildTitle = (
-  altosLabsCatalogEntity: AltosLabsCatalogEntity
-): React.ComponentProps<typeof C.Link> => {
-  const { shorthand, title } = altosLabsCatalogEntity;
-  return {
-    label: title,
-    url: shorthand ? `/experiments/${shorthand}` : "",
   };
 };
 

--- a/explorer/site-config/altos-labs-catalog/dev/config.ts
+++ b/explorer/site-config/altos-labs-catalog/dev/config.ts
@@ -21,6 +21,10 @@ const config: SiteConfig = {
       label: "DOI",
     },
     {
+      key: ALTOS_LABS_CATALOG_FILTER_CATEGORY_KEYS.EXPERIMENT,
+      label: "Experiment",
+    },
+    {
       key: ALTOS_LABS_CATALOG_FILTER_CATEGORY_KEYS.EXPERIMENT_TYPE,
       label: "Experiment Type",
     },
@@ -39,10 +43,6 @@ const config: SiteConfig = {
     {
       key: ALTOS_LABS_CATALOG_FILTER_CATEGORY_KEYS.TISSUE,
       label: "Tissue",
-    },
-    {
-      key: ALTOS_LABS_CATALOG_FILTER_CATEGORY_KEYS.TITLE,
-      label: "Title",
     },
   ],
   dataSource: {

--- a/explorer/site-config/altos-labs-catalog/dev/index/experimentEntityConfig.ts
+++ b/explorer/site-config/altos-labs-catalog/dev/index/experimentEntityConfig.ts
@@ -63,12 +63,12 @@ export const experimentEntity: EntityConfig<AltosLabsCatalogExperiment> = {
       {
         componentConfig: {
           component: Components.Link,
-          viewBuilder: ViewBuilder.buildTitle,
+          viewBuilder: ViewBuilder.buildExperiment,
         } as ComponentConfig<typeof Components.Link>,
-        header: "Title",
+        header: "Experiment",
         sort: {
           default: true,
-          sortKey: ALTOS_LABS_CATALOG_FILTER_CATEGORY_KEYS.TITLE,
+          sortKey: ALTOS_LABS_CATALOG_FILTER_CATEGORY_KEYS.EXPERIMENT,
         },
         width: { max: "1.5fr", min: "200px" },
       },

--- a/explorer/site-config/altos-labs-catalog/dev/index/fileEntityConfig.ts
+++ b/explorer/site-config/altos-labs-catalog/dev/index/fileEntityConfig.ts
@@ -75,12 +75,12 @@ export const fileEntity: EntityConfig<AltosLabsCatalogFile> = {
       {
         componentConfig: {
           component: Components.Link,
-          viewBuilder: ViewBuilder.buildTitle,
+          viewBuilder: ViewBuilder.buildExperiment,
         } as ComponentConfig<typeof Components.Link>,
         header: "Experiment",
         sort: {
           default: true,
-          sortKey: ALTOS_LABS_CATALOG_FILTER_CATEGORY_KEYS.TITLE,
+          sortKey: ALTOS_LABS_CATALOG_FILTER_CATEGORY_KEYS.EXPERIMENT,
         },
         width: { max: "1.5fr", min: "200px" },
       },

--- a/explorer/site-config/altos-labs-catalog/filter-category-keys.ts
+++ b/explorer/site-config/altos-labs-catalog/filter-category-keys.ts
@@ -1,6 +1,7 @@
 export const ALTOS_LABS_CATALOG_FILTER_CATEGORY_KEYS = {
   ASSAY: "assay",
   DOI: "doi",
+  EXPERIMENT: "title",
   EXPERIMENT_TYPE: "experimentType",
   FILE_TYPE: "fileType",
   INITIATIVE: "initiative",
@@ -8,5 +9,4 @@ export const ALTOS_LABS_CATALOG_FILTER_CATEGORY_KEYS = {
   SHORTHAND: "shorthand",
   SPECIES: "species",
   TISSUE: "tissue",
-  TITLE: "title",
 };


### PR DESCRIPTION
### Ticket
Closes https://github.com/clevercanary/altos-data-browser/issues/19

### Reviewers
@NoopDog

### Changes
- Modified experiment entity column "Title" heading to "Experiment" and corresponding filter label.

### Definition of Done (from ticket)
- Experiment tab "Title" heading changed to "Experiment" and filter updated to "Experiment" as well.
