### PR TITLE
feat: don't hide selected filters that no longer match the result set (#660)

### DIFF
--- a/explorer/app/components/Table/table.tsx
+++ b/explorer/app/components/Table/table.tsx
@@ -202,7 +202,7 @@ export const TableComponent = <T extends object>({
             previousIndex: null,
             rows: tableInstance.getFilteredRowModel().rows.length,
           },
-          selectCategories: buildCategoryViews(allColumns),
+          selectCategories: buildCategoryViews(allColumns, columnFilters),
         },
         type: ExploreActionKind.ProcessExploreResponse,
       });

--- a/explorer/app/hooks/useEntityList.ts
+++ b/explorer/app/hooks/useEntityList.ts
@@ -84,7 +84,7 @@ export const useEntityList = (
           listItems: data?.hits,
           loading: isLoading || isIdle,
           paginationResponse: transformAzulPagination(data?.pagination),
-          selectCategories: transformTermFacets(termFacets),
+          selectCategories: transformTermFacets(termFacets, filterState),
         },
         type: ExploreActionKind.ProcessExploreResponse,
       });
@@ -93,6 +93,7 @@ export const useEntityList = (
     data?.hits,
     data?.pagination,
     exploreDispatch,
+    filterState,
     isIdle,
     isLoading,
     listStaticLoad,


### PR DESCRIPTION
### Ticket
Closes #660 

### Reviewers
@NoopDog 

### Changes
- Added functionality to filter category to always show a selected result (even when the result has subsequently been filtered out).

### Definition of Done (from ticket)
- When there are no possible values of a selected filter, the filter remains in the left-hand list.