### PR TITLE
feat: update header to match refined mocks (#569)

### DIFF
--- a/explorer/app/components/Layout/common/entities.ts
+++ b/explorer/app/components/Layout/common/entities.ts
@@ -1,5 +1,6 @@
 import { Social } from "../../common/Socials/socials";
 import { ImageSrc } from "../../common/StaticImage/staticImage";
+import { MenuItem } from "../components/Header/components/NavLinkMenu/navLinkMenu";
 import { NavAlignment } from "../components/Header/components/NavLinks/navLinks";
 
 /**
@@ -41,5 +42,6 @@ export interface Logo {
  */
 export interface NavLinkItem {
   label: string;
+  menuItems?: MenuItem[];
   url: string;
 }

--- a/explorer/app/components/Layout/components/Footer/footer.stories.tsx
+++ b/explorer/app/components/Layout/components/Footer/footer.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { SOCIAL } from "app/components/common/Socials/socials";
 import logoHhs from "images/logoHhs.svg";
 import logoHumanCellAtlas from "images/logoHumanCellAtlas.png";
 import logoLungmap from "images/logoLungmap.png";
@@ -67,19 +68,19 @@ AnvilFooter.args = {
     ],
     socials: [
       {
-        type: "discourse",
+        ...SOCIAL.DISCOURSE,
         url: "https://help.anvilproject.org/",
       },
       {
-        type: "twitter",
+        ...SOCIAL.TWITTER,
         url: "https://twitter.com/useAnVIL",
       },
       {
-        type: "youtube",
+        ...SOCIAL.YOUTUBE,
         url: "https://www.youtube.com/channel/UCBbHCj7kUogAMFyBAzzzfUw",
       },
       {
-        type: "github",
+        ...SOCIAL.GITHUB,
         url: "https://github.com/anvilproject",
       },
     ],
@@ -118,15 +119,15 @@ HCAFooter.args = {
     ],
     socials: [
       {
-        type: "twitter",
+        ...SOCIAL.TWITTER,
         url: "https://twitter.com/humancellatlas",
       },
       {
-        type: "github",
+        ...SOCIAL.GITHUB,
         url: "https://github.com/HumanCellAtlas",
       },
       {
-        type: "slack",
+        ...SOCIAL.SLACK,
         url: "https://humancellatlas.slack.com/archives/C02TM2SDVM2",
       },
     ],
@@ -152,7 +153,7 @@ LungMapFooter.args = {
     ],
     socials: [
       {
-        type: "twitter",
+        ...SOCIAL.TWITTER,
         url: "https://twitter.com/lungmapnet",
       },
     ],

--- a/explorer/app/components/Layout/components/Header/common/utils.ts
+++ b/explorer/app/components/Layout/components/Header/common/utils.ts
@@ -1,0 +1,48 @@
+import { CustomIcon } from "../../../../common/CustomIcon/customIcon";
+import { Social } from "../../../../common/Socials/socials";
+import { ANCHOR_TARGET } from "../../../../Links/common/entities";
+import { NavLinkItem } from "../../../common/entities";
+import { MenuItem } from "../components/NavLinkMenu/navLinkMenu";
+
+/**
+ * Returns header navigation links for the specified media breakpoint query.
+ * @param links - Header navigation links.
+ * @param socials - Header socials.
+ * @param onlySmDesktop - Media breakpoint query is "true" for small desktop only.
+ * @returns header navigation links.
+ */
+export function getHeaderNavigationLinks(
+  links: NavLinkItem[],
+  socials: Social[],
+  onlySmDesktop: boolean
+): NavLinkItem[] {
+  if (onlySmDesktop) {
+    const navLinks = [...links];
+    if (socials) {
+      navLinks.push({
+        label: "Follow Us",
+        menuItems: getFollowUsMenuItems(socials),
+        url: "",
+      });
+    }
+    return navLinks;
+  }
+  // Return the links without the "More" or "Follow Us" menu.
+  return links.flatMap((link) => link.menuItems || link);
+}
+
+/**
+ * Returns menu items for the "Follow Us" menu.
+ * @param socials - Social configuration.
+ * @returns a list of social menu items for the "Follow Us" menu.
+ */
+function getFollowUsMenuItems(socials: Social[]): MenuItem[] {
+  return socials.map(({ label, type, url }) => {
+    return {
+      icon: CustomIcon({ fontSize: "small", iconName: type }),
+      label,
+      target: ANCHOR_TARGET.BLANK,
+      url,
+    };
+  });
+}

--- a/explorer/app/components/Layout/components/Header/components/Content/content.tsx
+++ b/explorer/app/components/Layout/components/Header/components/Content/content.tsx
@@ -4,20 +4,20 @@ import { HEADER_HEIGHT } from "../../header";
 
 interface Props {
   children: ReactNode | ReactNode[];
-  desktop: boolean;
+  desktopSm: boolean;
   drawerOpen: boolean;
   onDrawerClose: () => void;
 }
 
 export const Content = ({
   children,
-  desktop,
+  desktopSm,
   drawerOpen,
   onDrawerClose,
 }: Props): JSX.Element => {
-  const HeaderContent = desktop ? Fragment : Drawer;
-  const HeaderContentContainer = desktop ? Fragment : Box;
-  const contentProps = desktop
+  const HeaderContent = desktopSm ? Fragment : Drawer;
+  const HeaderContentContainer = desktopSm ? Fragment : Box;
+  const contentProps = desktopSm
     ? {}
     : {
         ModalProps: { sx: { top: `${HEADER_HEIGHT}px` } },
@@ -29,7 +29,7 @@ export const Content = ({
         onClose: onDrawerClose,
         open: drawerOpen,
       };
-  const contentContainerProps = desktop
+  const contentContainerProps = desktopSm
     ? {}
     : { sx: { display: "grid", gap: 2, py: 4 } };
 

--- a/explorer/app/components/Layout/components/Header/components/NavLinkMenu/navLinkMenu.styles.ts
+++ b/explorer/app/components/Layout/components/Header/components/NavLinkMenu/navLinkMenu.styles.ts
@@ -8,7 +8,7 @@ export const NavLinkMenu = styled(Menu)`
     border-color: ${({ theme }) => theme.palette.smoke.main};
   }
 
-  & .MuiListItemIcon-root {
+  && .MuiListItemIcon-root {
     min-width: 24px;
   }
 `;

--- a/explorer/app/components/Layout/components/Header/components/NavLinks/navLinks.tsx
+++ b/explorer/app/components/Layout/components/Header/components/NavLinks/navLinks.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import React from "react";
 import { ELEMENT_ALIGNMENT } from "../../../../../../common/entities";
 import { NavLinkItem } from "../../../../common/entities";
+import { NavLinkMenu } from "../NavLinkMenu/navLinkMenu";
 
 export type NavAlignment = Exclude<ELEMENT_ALIGNMENT, ELEMENT_ALIGNMENT.RIGHT>;
 
@@ -16,27 +17,31 @@ export const NavLinks = ({ center = false, links }: Props): JSX.Element => {
     <Box
       display="flex"
       flex={1}
-      flexDirection={{ desktop: "row", mobile: "column" }}
+      flexDirection={{ desktopSm: "row", mobile: "column" }}
       gap={2}
       justifyContent={{
-        desktop: center ? "center" : "flex-start",
+        desktopSm: center ? "center" : "flex-start",
         mobile: undefined,
       }}
-      marginLeft={{ desktop: center ? undefined : 6, mobile: undefined }}
+      marginLeft={{ desktopSm: center ? undefined : 6, mobile: undefined }}
     >
-      {links.map(({ label, url }) => (
-        <Link key={url} href={url} passHref>
-          <Button
-            href="passHref"
-            sx={{
-              justifyContent: { desktop: "unset", mobile: "flex-start" },
-            }}
-            variant="nav"
-          >
-            {label}
-          </Button>
-        </Link>
-      ))}
+      {links.map(({ label, menuItems, url }) =>
+        menuItems ? (
+          <NavLinkMenu key={label} menuItems={menuItems} menuLabel={label} />
+        ) : (
+          <Link key={url} href={url} passHref>
+            <Button
+              href="passHref"
+              sx={{
+                justifyContent: { desktopSm: "unset", mobile: "flex-start" },
+              }}
+              variant="nav"
+            >
+              {label}
+            </Button>
+          </Link>
+        )
+      )}
     </Box>
   );
 };

--- a/explorer/app/components/Layout/components/Header/components/ProfileComponent/profileComponent.tsx
+++ b/explorer/app/components/Layout/components/Header/components/ProfileComponent/profileComponent.tsx
@@ -13,15 +13,15 @@ export const ProfileComponent = (): JSX.Element => {
   const { isAuthorized, requestAuthorization, userProfile } =
     useContext(AuthContext);
   const profileImageURL = userProfile?.picture;
-  const desktop = useBreakpointHelper(
+  const smDesktop = useBreakpointHelper(
     BREAKPOINT_FN_NAME.UP,
-    BREAKPOINT.DESKTOP
+    BREAKPOINT.DESKTOP_SM
   );
   return (
     <>
       {isAuthorized ? (
         <ProfileImage profileImageURL={profileImageURL} />
-      ) : desktop ? (
+      ) : smDesktop ? (
         <Button
           startIcon={<LoginRoundedIcon />}
           variant="nav"

--- a/explorer/app/components/Layout/components/Header/components/Search/search.tsx
+++ b/explorer/app/components/Layout/components/Header/components/Search/search.tsx
@@ -8,13 +8,13 @@ import {
 import { SearchIcon } from "../../../../../common/CustomIcon/components/SearchIcon/searchIcon";
 
 export const Search = (): JSX.Element => {
-  const desktop = useBreakpointHelper(
+  const smDesktop = useBreakpointHelper(
     BREAKPOINT_FN_NAME.UP,
-    BREAKPOINT.DESKTOP
+    BREAKPOINT.DESKTOP_SM
   );
   return (
     <>
-      {desktop ? (
+      {smDesktop ? (
         <Button startIcon={<SearchIcon />} variant="nav">
           Search
         </Button>

--- a/explorer/app/components/Layout/components/Header/header.stories.tsx
+++ b/explorer/app/components/Layout/components/Header/header.stories.tsx
@@ -1,4 +1,5 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
+import { SOCIAL } from "app/components/common/Socials/socials";
 import logoAnvil from "images/logoAnvil.png";
 import logoHca from "images/logoHca.png";
 import logoLungmap from "images/logoLungmap.png";
@@ -63,35 +64,41 @@ AnvilHeader.args = {
         url: "https://anvilproject.org/events",
       },
       {
-        label: "Team",
-        url: "https://anvilproject.org/team",
-      },
-      {
-        label: "FAQ",
-        url: "https://anvilproject.org/faq",
-      },
-      {
-        label: "Help",
-        url: "https://anvilproject.org/help",
+        label: "More",
+        menuItems: [
+          {
+            label: "Team",
+            url: "https://anvilproject.org/team",
+          },
+          {
+            label: "FAQ",
+            url: "https://anvilproject.org/faq",
+          },
+          {
+            label: "Help",
+            url: "https://anvilproject.org/help",
+          },
+        ],
+        url: "",
       },
     ],
     searchEnabled: true,
     slogan: "NHGRI Analysis Visualization and Informatics Lab-space",
     socials: [
       {
-        type: "twitter",
+        ...SOCIAL.TWITTER,
         url: "https://twitter.com/useAnVIL",
       },
       {
-        type: "youtube",
+        ...SOCIAL.YOUTUBE,
         url: "https://www.youtube.com/channel/UCBbHCj7kUogAMFyBAzzzfUw",
       },
       {
-        type: "discourse",
+        ...SOCIAL.DISCOURSE,
         url: "https://help.anvilproject.org/",
       },
       {
-        type: "github",
+        ...SOCIAL.GITHUB,
         url: "https://github.com/anvilproject",
       },
     ],
@@ -147,15 +154,15 @@ HCAHeader.args = {
     slogan: undefined,
     socials: [
       {
-        type: "twitter",
+        ...SOCIAL.TWITTER,
         url: "https://twitter.com/humancellatlas",
       },
       {
-        type: "github",
+        ...SOCIAL.GITHUB,
         url: "https://github.com/HumanCellAtlas",
       },
       {
-        type: "slack",
+        ...SOCIAL.SLACK,
         url: "https://humancellatlas.slack.com/archives/C02TM2SDVM2",
       },
     ],
@@ -191,7 +198,7 @@ LungMapHeader.args = {
     slogan: undefined,
     socials: [
       {
-        type: "twitter",
+        ...SOCIAL.TWITTER,
         url: "https://twitter.com/lungmapnet",
       },
     ],

--- a/explorer/app/components/Layout/components/Header/header.tsx
+++ b/explorer/app/components/Layout/components/Header/header.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../../../hooks/useBreakpointHelper";
 import { Socials } from "../../../common/Socials/socials";
 import { Header as HeaderProps } from "../../common/entities";
+import { getHeaderNavigationLinks } from "./common/utils";
 import { Content } from "./components/Content/content";
 import { Logo } from "./components/Logo/logo";
 import { NavLinks } from "./components/NavLinks/navLinks";
@@ -35,17 +36,21 @@ export const Header = ({ header }: Props): JSX.Element => {
     socials,
   } = header;
   const [drawerOpen, setDrawerOpen] = useState(false);
-  const desktop = useBreakpointHelper(
+  const smDesktop = useBreakpointHelper(
     BREAKPOINT_FN_NAME.UP,
-    BREAKPOINT.DESKTOP
+    BREAKPOINT.DESKTOP_SM
+  );
+  const onlySmDesktop = useBreakpointHelper(
+    BREAKPOINT_FN_NAME.ONLY,
+    BREAKPOINT.DESKTOP_SM
   );
 
-  // Set drawer open state to false on change of media breakpoint from mobile to desktop.
+  // Set drawer open state to false on change of media breakpoint from mobile to "small desktop".
   useEffect(() => {
-    if (desktop) {
+    if (smDesktop) {
       setDrawerOpen(false);
     }
-  }, [desktop]);
+  }, [smDesktop]);
 
   return (
     <AppBar elevation={1} position="fixed">
@@ -53,12 +58,12 @@ export const Header = ({ header }: Props): JSX.Element => {
         {/* Logo */}
         <Logo logo={logo} />
         <Content
-          desktop={desktop}
+          desktopSm={smDesktop}
           drawerOpen={drawerOpen}
           onDrawerClose={(): void => setDrawerOpen(false)}
         >
           {/* Slogan divider */}
-          {slogan && desktop && (
+          {slogan && smDesktop && (
             <Divider orientation="vertical" sx={{ maxHeight: 32 }} />
           )}
           {/* Slogan */}
@@ -66,11 +71,11 @@ export const Header = ({ header }: Props): JSX.Element => {
             <Typography
               component="div"
               sx={
-                desktop
+                smDesktop
                   ? { fontSize: 12, lineHeight: "18px", maxWidth: 180 }
                   : { px: 6, py: 2 }
               }
-              variant={desktop ? undefined : "text-body-400"}
+              variant={smDesktop ? undefined : "text-body-400"}
             >
               {slogan}
             </Typography>
@@ -78,27 +83,29 @@ export const Header = ({ header }: Props): JSX.Element => {
           {/* Nav links */}
           <NavLinks
             center={navAlignment === ELEMENT_ALIGNMENT.CENTER}
-            links={navLinks}
+            links={getHeaderNavigationLinks(navLinks, socials, onlySmDesktop)}
           />
           {/* Socials */}
-          <Socials
-            buttonSize={desktop ? "small" : "xlarge"}
-            socials={socials}
-            sx={{
-              gap: desktop ? 2 : 4,
-              px: desktop ? undefined : 4,
-              py: desktop ? undefined : 2,
-            }}
-          />
+          {!onlySmDesktop && (
+            <Socials
+              buttonSize={smDesktop ? "small" : "xlarge"}
+              socials={socials}
+              sx={{
+                gap: smDesktop ? 2 : 4,
+                px: smDesktop ? undefined : 4,
+                py: smDesktop ? undefined : 2,
+              }}
+            />
+          )}
         </Content>
         {/* Actions */}
-        {(searchEnabled || authenticationEnabled || !desktop) && (
+        {(searchEnabled || authenticationEnabled || !smDesktop) && (
           <Box
             sx={{
               alignItems: "center",
               display: "flex",
-              flex: { desktop: "none", mobile: 1 },
-              gap: { desktop: 2, mobile: 3 },
+              flex: { desktopSm: "none", mobile: 1 },
+              gap: { desktopSm: 2, mobile: 3 },
               justifyContent: "flex-end",
             }}
           >
@@ -107,7 +114,7 @@ export const Header = ({ header }: Props): JSX.Element => {
             {/* LoginView */}
             {authenticationEnabled && <ProfileComponent />}
             {/* Menu */}
-            {!desktop && (
+            {!smDesktop && (
               <IconButton
                 aria-label="drawer"
                 color="ink"

--- a/explorer/app/components/common/Socials/socials.stories.tsx
+++ b/explorer/app/components/common/Socials/socials.stories.tsx
@@ -1,6 +1,6 @@
 import { ComponentMeta, ComponentStory } from "@storybook/react";
 import React from "react";
-import { Socials } from "./socials";
+import { SOCIAL, Socials } from "./socials";
 
 export default {
   argTypes: {
@@ -20,23 +20,23 @@ export const Primary = Template.bind({});
 Primary.args = {
   socials: [
     {
-      type: "twitter",
+      ...SOCIAL.TWITTER,
       url: GITHUB_URL,
     },
     {
-      type: "github",
+      ...SOCIAL.GITHUB,
       url: GITHUB_URL,
     },
     {
-      type: "youtube",
+      ...SOCIAL.YOUTUBE,
       url: GITHUB_URL,
     },
     {
-      type: "discourse",
+      ...SOCIAL.DISCOURSE,
       url: GITHUB_URL,
     },
     {
-      type: "slack",
+      ...SOCIAL.SLACK,
       url: GITHUB_URL,
     },
   ],

--- a/explorer/app/components/common/Socials/socials.tsx
+++ b/explorer/app/components/common/Socials/socials.tsx
@@ -6,7 +6,16 @@ import { IconName } from "../CustomIcon/common/iconSvgPathShapes";
 import { CustomIcon } from "../CustomIcon/customIcon";
 import { IconButtonSocials } from "../IconButton/iconButton.styles";
 
+export const SOCIAL: Record<string, Omit<Social, "url">> = {
+  DISCOURSE: { label: "Discourse", type: "discourse" },
+  GITHUB: { label: "GitHub", type: "github" },
+  SLACK: { label: "Slack", type: "slack" },
+  TWITTER: { label: "Twitter", type: "twitter" },
+  YOUTUBE: { label: "YouTube", type: "youtube" },
+};
+
 export interface Social {
+  label: string;
   type: IconName;
   url: string;
 }

--- a/explorer/app/hooks/useBreakpointHelper.ts
+++ b/explorer/app/hooks/useBreakpointHelper.ts
@@ -7,17 +7,19 @@ import { Breakpoint, Theme, useMediaQuery } from "@mui/material";
 
 export const enum BREAKPOINT {
   DESKTOP = "desktop",
+  DESKTOP_SM = "desktopSm",
   MOBILE = "mobile",
   TABLET = "tablet",
 }
 
 export const enum BREAKPOINT_FN_NAME {
   DOWN = "down",
+  ONLY = "only",
   UP = "up",
 }
 
 type BreakpointFnName = BREAKPOINT_FN_NAME;
-type BreakpointKey = Breakpoint | number;
+type BreakpointKey = Breakpoint;
 
 export const useBreakpointHelper = (
   fnName: BreakpointFnName,

--- a/explorer/app/theme/definitions.d.ts
+++ b/explorer/app/theme/definitions.d.ts
@@ -41,6 +41,7 @@ declare module "@mui/material/styles" {
     xl: false;
     [BREAKPOINT.MOBILE]: true;
     [BREAKPOINT.DESKTOP]: true;
+    [BREAKPOINT.DESKTOP_SM]: true;
     [BREAKPOINT.TABLET]: true;
   }
 

--- a/explorer/app/theme/theme.ts
+++ b/explorer/app/theme/theme.ts
@@ -7,6 +7,7 @@ import { BREAKPOINT } from "../hooks/useBreakpointHelper";
  */
 export const breakpointMobile = 0;
 export const breakpointTablet = 768; // Tablet.
+export const breakpointDesktopSm = 1280; // Desktop - small.
 export const breakpointDesktop = 1440; // Desktop.
 
 /**
@@ -47,6 +48,7 @@ export const getAppTheme = (customTheme?: ThemeOptions): Theme => {
       breakpoints: {
         values: {
           [BREAKPOINT.DESKTOP]: breakpointDesktop,
+          [BREAKPOINT.DESKTOP_SM]: breakpointDesktopSm,
           [BREAKPOINT.MOBILE]: breakpointMobile,
           [BREAKPOINT.TABLET]: breakpointTablet,
         },
@@ -202,6 +204,9 @@ export const getAppTheme = (customTheme?: ThemeOptions): Theme => {
    * Breakpoint constants
    */
   const breakpointUpDesktop = defaultTheme.breakpoints.up(BREAKPOINT.DESKTOP);
+  const breakpointUpDesktopSm = defaultTheme.breakpoints.up(
+    BREAKPOINT.DESKTOP_SM
+  );
   const breakpointUpMobile = defaultTheme.breakpoints.up(BREAKPOINT.MOBILE);
   const breakpointUpTablet = defaultTheme.breakpoints.up(BREAKPOINT.TABLET);
 
@@ -371,7 +376,7 @@ export const getAppTheme = (customTheme?: ThemeOptions): Theme => {
               "&:hover": {
                 backgroundColor: smokeLight,
               },
-              [breakpointUpDesktop]: {
+              [breakpointUpDesktopSm]: {
                 padding: "6px 12px",
               },
             },

--- a/explorer/site-config/anvil-cmg/dev/config.ts
+++ b/explorer/site-config/anvil-cmg/dev/config.ts
@@ -1,4 +1,3 @@
-import { Social } from "app/components/common/Socials/socials";
 import logoAnvil from "images/logoAnvil.png";
 import logoHhs from "images/logoHhs.svg";
 import logoNhgri from "images/logoNhgri.svg";
@@ -9,6 +8,7 @@ import { ELEMENT_ALIGNMENT } from "../../../app/common/entities";
 import { Logo } from "../../../app/components/Layout/common/entities";
 import { SiteConfig } from "../../../app/config/common/entities";
 import { authenticationConfig } from "./authentication/authentication";
+import { socials } from "./constants";
 import { exportConfig } from "./export/export";
 import { activitiesEntityConfig } from "./index/activitiesEntityConfig";
 import { biosamplesEntityConfig } from "./index/biosamplesEntityConfig";
@@ -27,28 +27,6 @@ const LOGO: Logo = {
   link: "/",
   src: logoAnvil,
 };
-const SOCIALS: Social[] = [
-  {
-    type: "discourse",
-    url: "https://help.anvilproject.org/",
-  },
-  {
-    type: "twitter",
-    url: "https://twitter.com/useAnVIL",
-  },
-  {
-    type: "youtube",
-    url: "https://www.youtube.com/channel/UCBbHCj7kUogAMFyBAzzzfUw",
-  },
-  {
-    type: "github",
-    url: "https://github.com/anvilproject",
-  },
-  {
-    type: "slack",
-    url: "https://join.slack.com/t/anvil-community/shared_invite/zt-hsyfam1w-LXlCv~3vNLSfDj~qNd5uBg",
-  },
-];
 
 const config: SiteConfig = {
   authentication: authenticationConfig,
@@ -166,7 +144,7 @@ const config: SiteConfig = {
           url: `${BROWSER_URL}/privacy`,
         },
       ],
-      socials: SOCIALS,
+      socials,
     },
     header: {
       authenticationEnabled: true,
@@ -208,7 +186,7 @@ const config: SiteConfig = {
       ],
       searchEnabled: false,
       slogan: SLOGAN,
-      socials: SOCIALS,
+      socials,
     },
   },
   redirectRootToPath: "/datasets",

--- a/explorer/site-config/anvil-cmg/dev/constants.ts
+++ b/explorer/site-config/anvil-cmg/dev/constants.ts
@@ -1,0 +1,24 @@
+import { SOCIAL, Social } from "../../../app/components/common/Socials/socials";
+
+export const socials: Social[] = [
+  {
+    ...SOCIAL.DISCOURSE,
+    url: "https://help.anvilproject.org/",
+  },
+  {
+    ...SOCIAL.TWITTER,
+    url: "https://twitter.com/useAnVIL",
+  },
+  {
+    ...SOCIAL.YOUTUBE,
+    url: "https://www.youtube.com/channel/UCBbHCj7kUogAMFyBAzzzfUw",
+  },
+  {
+    ...SOCIAL.GITHUB,
+    url: "https://github.com/anvilproject",
+  },
+  {
+    ...SOCIAL.SLACK,
+    url: "https://join.slack.com/t/anvil-community/shared_invite/zt-hsyfam1w-LXlCv~3vNLSfDj~qNd5uBg",
+  },
+];

--- a/explorer/site-config/anvil/dev/config.ts
+++ b/explorer/site-config/anvil/dev/config.ts
@@ -1,4 +1,3 @@
-import { Social } from "app/components/common/Socials/socials";
 import logoAnvil from "images/logoAnvil.png";
 import logoHhs from "images/logoHhs.svg";
 import logoNhgri from "images/logoNhgri.svg";
@@ -10,6 +9,7 @@ import { Logo } from "../../../app/components/Layout/common/entities";
 import { SiteConfig } from "../../../app/config/common/entities";
 import { authenticationConfig } from "./authentication/authentication";
 import { ANVIL_CATEGORY_KEY, ANVIL_CATEGORY_LABEL } from "./category";
+import { socials } from "./constants";
 import { exportConfig } from "./export/export";
 import { activitiesEntityConfig } from "./index/activitiesEntityConfig";
 import { biosamplesEntityConfig } from "./index/biosamplesEntityConfig";
@@ -29,28 +29,6 @@ const LOGO: Logo = {
   link: "/",
   src: logoAnvil,
 };
-const SOCIALS: Social[] = [
-  {
-    type: "discourse",
-    url: "https://help.anvilproject.org/",
-  },
-  {
-    type: "twitter",
-    url: "https://twitter.com/useAnVIL",
-  },
-  {
-    type: "youtube",
-    url: "https://www.youtube.com/channel/UCBbHCj7kUogAMFyBAzzzfUw",
-  },
-  {
-    type: "github",
-    url: "https://github.com/anvilproject",
-  },
-  {
-    type: "slack",
-    url: "https://join.slack.com/t/anvil-community/shared_invite/zt-hsyfam1w-LXlCv~3vNLSfDj~qNd5uBg",
-  },
-];
 
 const config: SiteConfig = {
   authentication: authenticationConfig,
@@ -149,7 +127,7 @@ const config: SiteConfig = {
           url: `${BROWSER_URL}/privacy`,
         },
       ],
-      socials: SOCIALS,
+      socials,
     },
     header: {
       authenticationEnabled: true,
@@ -177,21 +155,27 @@ const config: SiteConfig = {
           url: `${BROWSER_URL}/events`,
         },
         {
-          label: "Team",
-          url: `${BROWSER_URL}/team`,
-        },
-        {
-          label: "FAQ",
-          url: `${BROWSER_URL}/faq`,
-        },
-        {
-          label: "Help",
-          url: `${BROWSER_URL}/help`,
+          label: "More",
+          menuItems: [
+            {
+              label: "Team",
+              url: `${BROWSER_URL}/team`,
+            },
+            {
+              label: "FAQ",
+              url: `${BROWSER_URL}/faq`,
+            },
+            {
+              label: "Help",
+              url: `${BROWSER_URL}/help`,
+            },
+          ],
+          url: "",
         },
       ],
       searchEnabled: false,
       slogan: SLOGAN,
-      socials: SOCIALS,
+      socials,
     },
   },
   redirectRootToPath: "/datasets",

--- a/explorer/site-config/anvil/dev/constants.ts
+++ b/explorer/site-config/anvil/dev/constants.ts
@@ -1,0 +1,24 @@
+import { SOCIAL, Social } from "../../../app/components/common/Socials/socials";
+
+export const socials: Social[] = [
+  {
+    ...SOCIAL.DISCOURSE,
+    url: "https://help.anvilproject.org/",
+  },
+  {
+    ...SOCIAL.TWITTER,
+    url: "https://twitter.com/useAnVIL",
+  },
+  {
+    ...SOCIAL.YOUTUBE,
+    url: "https://www.youtube.com/channel/UCBbHCj7kUogAMFyBAzzzfUw",
+  },
+  {
+    ...SOCIAL.GITHUB,
+    url: "https://github.com/anvilproject",
+  },
+  {
+    ...SOCIAL.SLACK,
+    url: "https://join.slack.com/t/anvil-community/shared_invite/zt-hsyfam1w-LXlCv~3vNLSfDj~qNd5uBg",
+  },
+];

--- a/explorer/site-config/hca-dcp/dev/config.ts
+++ b/explorer/site-config/hca-dcp/dev/config.ts
@@ -1,11 +1,11 @@
 import logoHca from "images/logoHca.png";
 import logoHumanCellAtlas from "images/logoHumanCellAtlas.png";
 import { ELEMENT_ALIGNMENT } from "../../../app/common/entities";
-import { Social } from "../../../app/components/common/Socials/socials";
 import { Logo } from "../../../app/components/Layout/common/entities";
 import { SiteConfig } from "../../../app/config/common/entities";
 import { breakpointTablet } from "../../../app/theme/theme";
 import { HCA_DCP_CATEGORY_KEY, HCA_DCP_CATEGORY_LABEL } from "../category";
+import { socials } from "./constants";
 import { exportConfig } from "./export/export";
 import { filesEntityConfig } from "./index/filesEntityConfig";
 import { samplesEntityConfig } from "./index/samplesEntityConfig";
@@ -24,20 +24,6 @@ const LOGO: Logo = {
   link: BROWSER_URL,
   src: logoHca,
 };
-const SOCIALS: Social[] = [
-  {
-    type: "twitter",
-    url: "https://twitter.com/humancellatlas",
-  },
-  {
-    type: "github",
-    url: "https://github.com/HumanCellAtlas",
-  },
-  {
-    type: "slack",
-    url: "https://humancellatlas.slack.com/archives/C02TM2SDVM2",
-  },
-];
 
 const config: SiteConfig = {
   browserURL: BROWSER_URL,
@@ -159,7 +145,7 @@ const config: SiteConfig = {
           url: `${BROWSER_URL}/contact`,
         },
       ],
-      socials: SOCIALS,
+      socials,
     },
     header: {
       authenticationEnabled: false,
@@ -201,7 +187,7 @@ const config: SiteConfig = {
       ],
       searchEnabled: false,
       slogan: undefined,
-      socials: SOCIALS,
+      socials,
     },
   },
   redirectRootToPath: PROJECTS_URL,

--- a/explorer/site-config/hca-dcp/dev/constants.ts
+++ b/explorer/site-config/hca-dcp/dev/constants.ts
@@ -1,5 +1,22 @@
+import { SOCIAL, Social } from "../../../app/components/common/Socials/socials";
+
 /**
  * File to hold constants that will be used for the HCA-DCP project.
  */
 
 export const PROJECTS_LABEL = "Projects";
+
+export const socials: Social[] = [
+  {
+    ...SOCIAL.TWITTER,
+    url: "https://twitter.com/humancellatlas",
+  },
+  {
+    ...SOCIAL.GITHUB,
+    url: "https://github.com/HumanCellAtlas",
+  },
+  {
+    ...SOCIAL.SLACK,
+    url: "https://humancellatlas.slack.com/archives/C02TM2SDVM2",
+  },
+];

--- a/explorer/site-config/lungmap/dev/config.ts
+++ b/explorer/site-config/lungmap/dev/config.ts
@@ -1,9 +1,9 @@
-import { Social } from "app/components/common/Socials/socials";
 import logoLungmap from "images/logoLungmap.png";
 import hcaConfig from "site-config/hca-dcp/dev/config";
 import { ELEMENT_ALIGNMENT } from "../../../app/common/entities";
 import { Logo } from "../../../app/components/Layout/common/entities";
 import { SiteConfig } from "../../../app/config/common/entities";
+import { socials } from "./constants";
 import { summary } from "./index/summary";
 
 // Template constants
@@ -16,12 +16,6 @@ const LOGO: Logo = {
   link: PROJECTS_URL,
   src: logoLungmap,
 };
-const SOCIALS: Social[] = [
-  {
-    type: "twitter",
-    url: "https://twitter.com/lungmapnet",
-  },
-];
 
 const config: SiteConfig = {
   browserURL: BROWSER_URL,
@@ -49,7 +43,7 @@ const config: SiteConfig = {
           url: `${BROWSER_URL}/lungmap-privacy`,
         },
       ],
-      socials: SOCIALS,
+      socials,
     },
     header: {
       authenticationEnabled: false,
@@ -71,7 +65,7 @@ const config: SiteConfig = {
       ],
       searchEnabled: false,
       slogan: undefined,
-      socials: SOCIALS,
+      socials,
     },
   },
   redirectRootToPath: PROJECTS_URL,

--- a/explorer/site-config/lungmap/dev/constants.ts
+++ b/explorer/site-config/lungmap/dev/constants.ts
@@ -1,0 +1,8 @@
+import { SOCIAL, Social } from "../../../app/components/common/Socials/socials";
+
+export const socials: Social[] = [
+  {
+    ...SOCIAL.TWITTER,
+    url: "https://twitter.com/lungmapnet",
+  },
+];

--- a/explorer/site-config/ncpi-catalog/dev/config.ts
+++ b/explorer/site-config/ncpi-catalog/dev/config.ts
@@ -6,6 +6,7 @@ import {
   NCPI_CATALOG_CATEGORY_KEY,
   NCPI_CATALOG_CATEGORY_LABEL,
 } from "../category";
+import { socials } from "./constants";
 import { platformsEntityConfig } from "./index/platformsEntityConfig";
 import { studiesEntityConfig } from "./index/studiesEntityConfig";
 
@@ -79,34 +80,27 @@ const config: SiteConfig = {
           url: `${BROWSER_URL}/ncpi/data`,
         },
         {
-          label: "Demonstration Projects",
-          url: `${BROWSER_URL}/ncpi/demonstration-projects`,
-        },
-        {
-          label: "Training",
-          url: `${BROWSER_URL}/ncpi/training`,
-        },
-        {
-          label: "Updates",
-          url: `${BROWSER_URL}/ncpi/progress-updates`,
+          label: "More",
+          menuItems: [
+            {
+              label: "Demonstration Projects",
+              url: `${BROWSER_URL}/ncpi/demonstration-projects`,
+            },
+            {
+              label: "Training",
+              url: `${BROWSER_URL}/ncpi/training`,
+            },
+            {
+              label: "Updates",
+              url: `${BROWSER_URL}/ncpi/progress-updates`,
+            },
+          ],
+          url: "",
         },
       ],
       searchEnabled: true,
       slogan: SLOGAN,
-      socials: [
-        {
-          type: "youtube",
-          url: "https://www.youtube.com/channel/UCJvPdDZOxJvOwObfnZ8X3gA",
-        },
-        {
-          type: "github",
-          url: "https://github.com/NIH-NCPI/",
-        },
-        {
-          type: "slack",
-          url: "https://nihcloudplatforms.slack.com/",
-        },
-      ],
+      socials,
     },
   },
   redirectRootToPath: "/studies",

--- a/explorer/site-config/ncpi-catalog/dev/constants.ts
+++ b/explorer/site-config/ncpi-catalog/dev/constants.ts
@@ -1,0 +1,16 @@
+import { SOCIAL, Social } from "../../../app/components/common/Socials/socials";
+
+export const socials: Social[] = [
+  {
+    ...SOCIAL.YOUTUBE,
+    url: "https://www.youtube.com/channel/UCJvPdDZOxJvOwObfnZ8X3gA",
+  },
+  {
+    ...SOCIAL.GITHUB,
+    url: "https://github.com/NIH-NCPI/",
+  },
+  {
+    ...SOCIAL.SLACK,
+    url: "https://nihcloudplatforms.slack.com/",
+  },
+];


### PR DESCRIPTION
### Ticket
Closes #569.

### Reviewers
@NoopDog

### Changes
- Modified header to match refined [mocks](https://www.figma.com/file/i4uZsYkKAML9ivi2TIo6ug/explore-dashboard?node-id=2718%3A27921&t=3SXJbJQKEb9lBN0c-4). Header navigation menu buttons "More" and "Follow Us" show between 1280px and 1440px.
  - Modified header configuration field to take a navigation menu item.
  - Modified social interface and associated configuration by extending the interface with a displayable social `label` value.
  - Refactored social configuration into `constants.ts` file.
  - Modified header component and all associated header components breakpoint from desktop to small desktop (1280px) as per mock. (Added new intermediate breakpoint `desktopSm`.)
  - 

### Definition of Done (from ticket)
- Header matches refined [mocks](https://www.figma.com/file/i4uZsYkKAML9ivi2TIo6ug/explore-dashboard?node-id=2718%3A27921&t=3SXJbJQKEb9lBN0c-4).