### PR TITLE
fix: show "no results" warning for catalog entities (#687)

### DIFF
--- a/explorer/app/components/Table/table.tsx
+++ b/explorer/app/components/Table/table.tsx
@@ -30,6 +30,7 @@ import {
 import { Pagination } from "../../common/entities";
 import { InfoIcon } from "../common/CustomIcon/components/InfoIcon/infoIcon";
 import { GridPaper, RoundedPaper } from "../common/Paper/paper.styles";
+import { NoResults } from "../NoResults/noResults";
 import {
   buildCategoryViews,
   getEditColumnOptions,
@@ -75,13 +76,15 @@ export const TableComponent = <T extends object>({
   initialState,
   items,
   total,
-}: TableProps<T>): JSX.Element => {
+}: // eslint-disable-next-line sonarjs/cognitive-complexity -- TODO fix component length / complexity
+TableProps<T>): JSX.Element => {
   const { exploreDispatch, exploreState } = useContext(ExploreStateContext);
   const {
     filterState,
     isRelatedView,
     listItems,
     listStaticLoad,
+    loading,
     paginationState,
     relatedListItems,
     sorting,
@@ -135,6 +138,8 @@ export const TableComponent = <T extends object>({
   } = tableInstance;
   const allColumns = getAllColumns();
   const { columnFilters } = getState();
+  const { rows: results } = getRowModel();
+  const noResults = !loading && (!results || results.length === 0);
   const scrollTop = useScroll();
   const isLastPage = currentPage === pages;
   const editColumnOptions = getEditColumnOptions(tableInstance);
@@ -242,7 +247,9 @@ export const TableComponent = <T extends object>({
     resetColumnVisibility(false);
   };
 
-  return (
+  return noResults ? (
+    <NoResults title={"No Results found"} />
+  ) : (
     <RoundedPaper>
       <GridPaper>
         {editColumnOptions && (

--- a/explorer/app/views/ExploreView/exploreView.tsx
+++ b/explorer/app/views/ExploreView/exploreView.tsx
@@ -1,6 +1,5 @@
 import { Tabs, TabValue } from "app/components/common/Tabs/tabs";
 import { ComponentCreator } from "app/components/ComponentCreator/ComponentCreator";
-import { NoResults } from "app/components/NoResults/noResults";
 import { TableCreator } from "app/components/TableCreator/tableCreator";
 import { useEntityList } from "app/hooks/useEntityList";
 import { useRouter } from "next/router";
@@ -132,28 +131,6 @@ function renderEntities(
     // loads with the previous tabs data on the first render after switching tabs. (or similar)
     //console.log("Entity list type != tab value", entityListType, tabValue);
     return <></>; // TODO(Fran) review loading and return.
-  }
-
-  if (!loading && (!listItems || listItems.length === 0)) {
-    return (
-      <NoResults
-        // actions={
-        //   <>
-        //     <ButtonPrimary
-        //       onClick={(): void => console.log("Remove last filter")} // TODO create "remove last filter" function
-        //     >
-        //       Remove last filter
-        //     </ButtonPrimary>
-        //     <ButtonSecondary
-        //       onClick={(): void => console.log("Clear all filters")} // TODO create "clear all filters" function
-        //     >
-        //       Clear all filters
-        //     </ButtonSecondary>
-        //   </>
-        // }
-        title={"No Results found"}
-      />
-    );
   }
 
   return (


### PR DESCRIPTION
### Ticket
Closes #687 

### Reviewers
@NoopDog 

### Changes
- Show "no results" warning for both catalog and azul entities.
  - Moved location of "no results" warning to table component.

### Definition of Done (from ticket)
- The "no results" warning shows for both catalog and azul entities.
