### PR TITLE
fix: doi filter is not showing any content (#32)

### DIFF
--- a/explorer/site-config/altos-labs-catalog/category.ts
+++ b/explorer/site-config/altos-labs-catalog/category.ts
@@ -1,7 +1,7 @@
 export const ALTOS_LABS_CATALOG_CATEGORY_KEY = {
   ASSAY: "assay",
   COLLECTION: "collection",
-  DOI: "doi",
+  DOI: "DOI",
   EXPERIMENT: "title",
   EXPERIMENT_TYPE: "experimentType",
   FILE_TYPE: "fileType",


### PR DESCRIPTION
### Ticket
Closes https://github.com/clevercanary/altos-data-browser/issues/32

### Reviewers
@NoopDog 

### Changes
- Modified DOI category key to reflect API.

### Definition of Done (from ticket)
- DOI filter shows content.
