### PR TITLE
feat: create matrix questionnaire component (#701)

### DIFF
--- a/explorer/app/components/common/MDXMarkdown/components/Section/mdxSection.styles.ts
+++ b/explorer/app/components/common/MDXMarkdown/components/Section/mdxSection.styles.ts
@@ -1,4 +1,5 @@
 import {
+  SectionActions as DXSectionActions,
   sectionMargin,
   sectionMarginSm,
 } from "@clevercanary/data-explorer-ui/lib/components/common/Section/section.styles";
@@ -32,4 +33,8 @@ export const Section = styled("div")`
   > *:last-child {
     margin-bottom: 0;
   }
+`;
+
+export const SectionActions = styled(DXSectionActions)`
+  margin: 16px 0;
 `;

--- a/explorer/app/content/hca-dcp/index.tsx
+++ b/explorer/app/content/hca-dcp/index.tsx
@@ -1,6 +1,10 @@
 export { RenderComponent } from "@clevercanary/data-explorer-ui/lib/components/ComponentCreator/components/RenderComponent/renderComponent";
-export { Section } from "../../components/common/MDXMarkdown/components/Section/mdxSection.styles";
+export {
+  Section,
+  SectionActions,
+} from "../../components/common/MDXMarkdown/components/Section/mdxSection.styles";
 export { default as BatchCorrectionWarning } from "./batchCorrectionWarning.mdx";
 export { default as ContributorGeneratedMatrices } from "./contributorGeneratedMatrices.mdx";
 export { default as DataReleasePolicy } from "./dataReleasePolicy.mdx";
 export { default as DCPGeneratedMatrices } from "./dcpGeneratedMatrices.mdx";
+export { default as MatrixQuestionnaire } from "./matrixQuestionnaire.mdx";

--- a/explorer/app/content/hca-dcp/matrixQuestionnaire.mdx
+++ b/explorer/app/content/hca-dcp/matrixQuestionnaire.mdx
@@ -1,0 +1,15 @@
+import { ButtonSecondary } from "@clevercanary/data-explorer-ui/lib/components/common/Button/button.styles";
+import { SectionActions } from "../../components/common/MDXMarkdown/components/Section/mdxSection.styles";
+import { ANCHOR_TARGET } from "@clevercanary/data-explorer-ui/lib/components/Links/common/entities";
+
+### Have matrix questions?
+
+Take a survey and sign up for a 1:1 session where you can receive help and share your experiences. You can also join the [#dcp-users](https://humancellatlas.slack.com/archives/C02TM2SDVM2) community on Slack.
+
+<SectionActions>
+  <ButtonSecondary
+    children="Sign up for private session"
+    href="https://docs.google.com/forms/d/e/1FAIpQLSfuX6Xn1KzjURXdPUjBoQGK3fbKQMUuh3JKs2MHS9xCSR2TQw/viewform"
+    target={ANCHOR_TARGET.BLANK}
+  />
+</SectionActions>

--- a/explorer/site-config/hca-dcp/dev/detail/project/matricesSideColumn.ts
+++ b/explorer/site-config/hca-dcp/dev/detail/project/matricesSideColumn.ts
@@ -8,6 +8,19 @@ export const sideColumn: ComponentConfig[] = [
       {
         children: [
           {
+            component: MDX.MatrixQuestionnaire,
+          } as ComponentConfig<typeof MDX.MatrixQuestionnaire>,
+        ],
+        component: MDX.Section,
+      } as ComponentConfig<typeof MDX.Section>,
+    ],
+    component: C.FluidPaper,
+  } as ComponentConfig<typeof C.FluidPaper>,
+  {
+    children: [
+      {
+        children: [
+          {
             component: MDX.DataReleasePolicy,
           } as ComponentConfig<typeof MDX.DataReleasePolicy>,
         ],


### PR DESCRIPTION
### Ticket
Closes #701 

### Reviewers
@NoopDog 

### Changes
- Added matrix questionnaire to matrix side column.

### Definition of Done (from ticket)
- HCA project matrices page displays matrix questionnaire component in the right-hand channel above the data use policy.
