### PR TITLE
feat: update data use policy to include links (#700)

### DIFF
--- a/explorer/app/content/hca-dcp/dataReleasePolicy.mdx
+++ b/explorer/app/content/hca-dcp/dataReleasePolicy.mdx
@@ -1,0 +1,1 @@
+Downloaded and exported data is governed by the [HCA Data Release Policy](https://www.humancellatlas.org/data-release-policy/) and licensed under the [Creative Commons Attribution 4.0 International License (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/). For more information please see our [Data Use Agreement](https://data.humancellatlas.org/about/data-use-agreement).

--- a/explorer/app/content/hca-dcp/index.tsx
+++ b/explorer/app/content/hca-dcp/index.tsx
@@ -1,0 +1,6 @@
+export { RenderComponent } from "@clevercanary/data-explorer-ui/lib/components/ComponentCreator/components/RenderComponent/renderComponent";
+export { Section } from "../../components/common/MDXMarkdown/components/Section/mdxSection.styles";
+export { default as BatchCorrectionWarning } from "./batchCorrectionWarning.mdx";
+export { default as ContributorGeneratedMatrices } from "./contributorGeneratedMatrices.mdx";
+export { default as DataReleasePolicy } from "./dataReleasePolicy.mdx";
+export { default as DCPGeneratedMatrices } from "./dcpGeneratedMatrices.mdx";

--- a/explorer/app/content/index.tsx
+++ b/explorer/app/content/index.tsx
@@ -1,7 +1,0 @@
-export { RenderComponent } from "@clevercanary/data-explorer-ui/lib/components/ComponentCreator/components/RenderComponent/renderComponent";
-export { Section } from "../components/common/MDXMarkdown/components/Section/mdxSection.styles";
-export { default as BatchCorrectionWarning } from "./hca-dcp/batchCorrectionWarning.mdx";
-export { default as ContributorGeneratedMatrices } from "./hca-dcp/contributorGeneratedMatrices.mdx";
-export { default as DataReleasePolicy } from "./hca-dcp/dataReleasePolicy.mdx";
-export { default as DCPGeneratedMatrices } from "./hca-dcp/dcpGeneratedMatrices.mdx";
-export { default as LungMAPDataReleasePolicy } from "./lungmap/dataReleasePolicy.mdx";

--- a/explorer/app/content/index.tsx
+++ b/explorer/app/content/index.tsx
@@ -2,4 +2,5 @@ export { RenderComponent } from "@clevercanary/data-explorer-ui/lib/components/C
 export { Section } from "../components/common/MDXMarkdown/components/Section/mdxSection.styles";
 export { default as BatchCorrectionWarning } from "./hca-dcp/batchCorrectionWarning.mdx";
 export { default as ContributorGeneratedMatrices } from "./hca-dcp/contributorGeneratedMatrices.mdx";
+export { default as DataReleasePolicy } from "./hca-dcp/dataReleasePolicy.mdx";
 export { default as DCPGeneratedMatrices } from "./hca-dcp/dcpGeneratedMatrices.mdx";

--- a/explorer/app/content/index.tsx
+++ b/explorer/app/content/index.tsx
@@ -4,3 +4,4 @@ export { default as BatchCorrectionWarning } from "./hca-dcp/batchCorrectionWarn
 export { default as ContributorGeneratedMatrices } from "./hca-dcp/contributorGeneratedMatrices.mdx";
 export { default as DataReleasePolicy } from "./hca-dcp/dataReleasePolicy.mdx";
 export { default as DCPGeneratedMatrices } from "./hca-dcp/dcpGeneratedMatrices.mdx";
+export { default as LungMAPDataReleasePolicy } from "./lungmap/dataReleasePolicy.mdx";

--- a/explorer/app/content/lungmap/dataReleasePolicy.mdx
+++ b/explorer/app/content/lungmap/dataReleasePolicy.mdx
@@ -1,0 +1,1 @@
+Downloaded data is governed by the [LungMAP Data Release Policy](https://lungmap.net/resources/data-access-policy/).

--- a/explorer/app/content/lungmap/index.tsx
+++ b/explorer/app/content/lungmap/index.tsx
@@ -1,0 +1,3 @@
+export { RenderComponent } from "@clevercanary/data-explorer-ui/lib/components/ComponentCreator/components/RenderComponent/renderComponent";
+export { Section } from "../../components/common/MDXMarkdown/components/Section/mdxSection.styles";
+export { default as DataReleasePolicy } from "./dataReleasePolicy.mdx";

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -71,21 +71,6 @@ export const buildContributorGeneratedMatricesTable = (
 };
 
 /**
- * Build props for TitledText component for the display of the data release policy section.
- * TODO replace with MDX data use policy.
- * @returns model to be used as props for the TitledText component.
- */
-export const buildDataReleasePolicy = (): React.ComponentProps<
-  typeof C.TitledText
-> => {
-  return {
-    text: [
-      "Downloaded data is governed by the HCA Data Release Policy and licensed under the Creative Commons Attribution 4.0 International License (CC BY 4.0). For more information please see our Data Use Agreement.",
-    ],
-  };
-};
-
-/**
  * Build props for GeneratedMatricesTable component from the given project response.
  * @param projectsResponse - Response model return from projects API.
  * @returns model to be used as props for the generated matrices table component.

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -72,6 +72,7 @@ export const buildContributorGeneratedMatricesTable = (
 
 /**
  * Build props for TitledText component for the display of the data release policy section.
+ * TODO replace with MDX data use policy.
  * @returns model to be used as props for the TitledText component.
  */
 export const buildDataReleasePolicy = (): React.ComponentProps<

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -1,6 +1,5 @@
 import { ColumnDef } from "@tanstack/react-table";
 import React from "react";
-import * as MDX from "../../../../../app/content/index";
 import {
   HCA_DCP_CATEGORY_KEY,
   HCA_DCP_CATEGORY_LABEL,
@@ -25,6 +24,7 @@ import { METADATA_KEY } from "../../../../components/Index/common/entities";
 import { getPluralizedMetadataLabel } from "../../../../components/Index/common/indexTransformer";
 import { formatCountSize } from "../../../../components/Index/common/utils";
 import { getProjectResponse } from "../../../../components/Project/common/projectTransformer";
+import * as MDX from "../../../../content/hca-dcp";
 import { ProjectsResponse } from "../../../../models/responses";
 import { humanFileSize } from "../../../../utils/fileSize";
 import {

--- a/explorer/site-config/hca-dcp/dev/detail/project/exportSideColumn.ts
+++ b/explorer/site-config/hca-dcp/dev/detail/project/exportSideColumn.ts
@@ -1,6 +1,6 @@
 import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "../../../../../app/components";
-import * as MDX from "../../../../../app/content";
+import * as MDX from "../../../../../app/content/hca-dcp";
 
 export const sideColumn: ComponentConfig[] = [
   {

--- a/explorer/site-config/hca-dcp/dev/detail/project/exportSideColumn.ts
+++ b/explorer/site-config/hca-dcp/dev/detail/project/exportSideColumn.ts
@@ -1,13 +1,19 @@
 import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "../../../../../app/components";
+import * as MDX from "../../../../../app/content";
 
 export const sideColumn: ComponentConfig[] = [
   {
-    component: C.TitledText,
-    viewBuilder: () => ({
-      text: [
-        "Downloaded data is governed by the HCA Data Release Policy and licensed under the Creative Commons Attribution 4.0 International License (CC BY 4.0). For more information please see our Data Use Agreement.",
-      ],
-    }),
-  } as ComponentConfig<typeof C.TitledText>,
+    children: [
+      {
+        children: [
+          {
+            component: MDX.DataReleasePolicy,
+          } as ComponentConfig<typeof MDX.DataReleasePolicy>,
+        ],
+        component: MDX.Section,
+      } as ComponentConfig<typeof MDX.Section>,
+    ],
+    component: C.FluidPaper,
+  } as ComponentConfig<typeof C.FluidPaper>,
 ];

--- a/explorer/site-config/hca-dcp/dev/detail/project/matricesMainColumn.ts
+++ b/explorer/site-config/hca-dcp/dev/detail/project/matricesMainColumn.ts
@@ -1,6 +1,6 @@
 import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "../../../../../app/components";
-import * as MDX from "../../../../../app/content/index";
+import * as MDX from "../../../../../app/content/hca-dcp";
 import { ProjectsResponse } from "../../../../../app/models/responses";
 import * as T from "../../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
 

--- a/explorer/site-config/hca-dcp/dev/detail/project/matricesSideColumn.ts
+++ b/explorer/site-config/hca-dcp/dev/detail/project/matricesSideColumn.ts
@@ -1,6 +1,6 @@
 import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "../../../../../app/components";
-import * as MDX from "../../../../../app/content/index";
+import * as MDX from "../../../../../app/content/hca-dcp";
 
 export const sideColumn: ComponentConfig[] = [
   {

--- a/explorer/site-config/hca-dcp/dev/detail/project/matricesSideColumn.ts
+++ b/explorer/site-config/hca-dcp/dev/detail/project/matricesSideColumn.ts
@@ -1,13 +1,19 @@
 import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "../../../../../app/components";
+import * as MDX from "../../../../../app/content/index";
 
 export const sideColumn: ComponentConfig[] = [
   {
-    component: C.TitledText,
-    viewBuilder: () => ({
-      text: [
-        "Downloaded data is governed by the HCA Data Release Policy and licensed under the Creative Commons Attribution 4.0 International License (CC BY 4.0). For more information please see our Data Use Agreement.",
-      ],
-    }),
-  } as ComponentConfig<typeof C.TitledText>,
+    children: [
+      {
+        children: [
+          {
+            component: MDX.DataReleasePolicy,
+          } as ComponentConfig<typeof MDX.DataReleasePolicy>,
+        ],
+        component: MDX.Section,
+      } as ComponentConfig<typeof MDX.Section>,
+    ],
+    component: C.FluidPaper,
+  } as ComponentConfig<typeof C.FluidPaper>,
 ];

--- a/explorer/site-config/hca-dcp/dev/detail/project/metadataSideColumn.ts
+++ b/explorer/site-config/hca-dcp/dev/detail/project/metadataSideColumn.ts
@@ -1,6 +1,6 @@
 import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "../../../../../app/components";
-import * as MDX from "../../../../../app/content";
+import * as MDX from "../../../../../app/content/hca-dcp";
 
 export const sideColumn: ComponentConfig[] = [
   {

--- a/explorer/site-config/hca-dcp/dev/detail/project/metadataSideColumn.ts
+++ b/explorer/site-config/hca-dcp/dev/detail/project/metadataSideColumn.ts
@@ -1,13 +1,19 @@
 import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "../../../../../app/components";
+import * as MDX from "../../../../../app/content";
 
 export const sideColumn: ComponentConfig[] = [
   {
-    component: C.TitledText,
-    viewBuilder: () => ({
-      text: [
-        "Downloaded data is governed by the HCA Data Release Policy and licensed under the Creative Commons Attribution 4.0 International License (CC BY 4.0). For more information please see our Data Use Agreement.",
-      ],
-    }),
-  } as ComponentConfig<typeof C.TitledText>,
+    children: [
+      {
+        children: [
+          {
+            component: MDX.DataReleasePolicy,
+          } as ComponentConfig<typeof MDX.DataReleasePolicy>,
+        ],
+        component: MDX.Section,
+      } as ComponentConfig<typeof MDX.Section>,
+    ],
+    component: C.FluidPaper,
+  } as ComponentConfig<typeof C.FluidPaper>,
 ];

--- a/explorer/site-config/hca-dcp/dev/detail/project/projectFilesSideColumn.ts
+++ b/explorer/site-config/hca-dcp/dev/detail/project/projectFilesSideColumn.ts
@@ -1,6 +1,6 @@
 import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "../../../../../app/components";
-import * as MDX from "../../../../../app/content";
+import * as MDX from "../../../../../app/content/hca-dcp";
 
 export const sideColumn: ComponentConfig[] = [
   {

--- a/explorer/site-config/hca-dcp/dev/detail/project/projectFilesSideColumn.ts
+++ b/explorer/site-config/hca-dcp/dev/detail/project/projectFilesSideColumn.ts
@@ -1,13 +1,19 @@
 import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "../../../../../app/components";
+import * as MDX from "../../../../../app/content";
 
 export const sideColumn: ComponentConfig[] = [
   {
-    component: C.TitledText,
-    viewBuilder: () => ({
-      text: [
-        "Downloaded data is governed by the HCA Data Release Policy and licensed under the Creative Commons Attribution 4.0 International License (CC BY 4.0). For more information please see our Data Use Agreement.",
-      ],
-    }),
-  } as ComponentConfig<typeof C.TitledText>,
+    children: [
+      {
+        children: [
+          {
+            component: MDX.DataReleasePolicy,
+          } as ComponentConfig<typeof MDX.DataReleasePolicy>,
+        ],
+        component: MDX.Section,
+      } as ComponentConfig<typeof MDX.Section>,
+    ],
+    component: C.FluidPaper,
+  } as ComponentConfig<typeof C.FluidPaper>,
 ];

--- a/explorer/site-config/hca-dcp/dev/export/export.ts
+++ b/explorer/site-config/hca-dcp/dev/export/export.ts
@@ -3,6 +3,7 @@ import {
   ComponentConfig,
 } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "app/components";
+import * as MDX from "../../../../app/content";
 import * as T from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
 
 export const exportConfig: BackPageConfig = {
@@ -28,9 +29,18 @@ export const exportConfig: BackPageConfig = {
       route: "/export",
       sideColumn: [
         {
-          component: C.TitledText,
-          viewBuilder: T.buildDataReleasePolicy,
-        } as ComponentConfig<typeof C.TitledText>,
+          children: [
+            {
+              children: [
+                {
+                  component: MDX.DataReleasePolicy,
+                } as ComponentConfig<typeof MDX.DataReleasePolicy>,
+              ],
+              component: MDX.Section,
+            } as ComponentConfig<typeof MDX.Section>,
+          ],
+          component: C.FluidPaper,
+        } as ComponentConfig<typeof C.FluidPaper>,
       ],
     },
   ],

--- a/explorer/site-config/hca-dcp/dev/export/export.ts
+++ b/explorer/site-config/hca-dcp/dev/export/export.ts
@@ -3,7 +3,7 @@ import {
   ComponentConfig,
 } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "app/components";
-import * as MDX from "../../../../app/content";
+import * as MDX from "../../../../app/content/hca-dcp";
 import * as T from "../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
 
 export const exportConfig: BackPageConfig = {

--- a/explorer/site-config/lungmap/dev/config.ts
+++ b/explorer/site-config/lungmap/dev/config.ts
@@ -3,7 +3,10 @@ import { LogoProps } from "@clevercanary/data-explorer-ui/lib/components/Layout/
 import { SiteConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import logoLungmap from "images/logoLungmap.png";
 import hcaConfig from "site-config/hca-dcp/dev/config";
+import { filesEntityConfig as hcaFilesEntityConfig } from "../../hca-dcp/dev/index/filesEntityConfig";
+import { samplesEntityConfig as hcaSamplesEntityConfig } from "../../hca-dcp/dev/index/samplesEntityConfig";
 import { socials } from "./constants";
+import { projectsEntityConfig } from "./index/projectsEntityConfig";
 import { summary } from "./index/summary";
 
 // Template constants
@@ -30,7 +33,11 @@ const config: SiteConfig = {
     // url: "https://service.dev.singlecell.gi.ucsc.edu/",
     url: "https://service.azul.data.humancellatlas.org/",
   },
-  entities: hcaConfig.entities,
+  entities: [
+    projectsEntityConfig,
+    hcaSamplesEntityConfig,
+    hcaFilesEntityConfig,
+  ],
   explorerTitle: "Explore Data",
   export: hcaConfig.export,
   exportToTerraUrl: hcaConfig.exportToTerraUrl,

--- a/explorer/site-config/lungmap/dev/config.ts
+++ b/explorer/site-config/lungmap/dev/config.ts
@@ -6,6 +6,7 @@ import hcaConfig from "site-config/hca-dcp/dev/config";
 import { filesEntityConfig as hcaFilesEntityConfig } from "../../hca-dcp/dev/index/filesEntityConfig";
 import { samplesEntityConfig as hcaSamplesEntityConfig } from "../../hca-dcp/dev/index/samplesEntityConfig";
 import { socials } from "./constants";
+import { exportConfig } from "./export/exportConfig";
 import { projectsEntityConfig } from "./index/projectsEntityConfig";
 import { summary } from "./index/summary";
 
@@ -39,7 +40,7 @@ const config: SiteConfig = {
     hcaFilesEntityConfig,
   ],
   explorerTitle: "Explore Data",
-  export: hcaConfig.export,
+  export: exportConfig,
   exportToTerraUrl: hcaConfig.exportToTerraUrl,
   layout: {
     footer: {

--- a/explorer/site-config/lungmap/dev/detail/project/exportSideColumn.ts
+++ b/explorer/site-config/lungmap/dev/detail/project/exportSideColumn.ts
@@ -1,0 +1,19 @@
+import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
+import * as C from "../../../../../app/components";
+import * as MDX from "../../../../../app/content";
+
+export const sideColumn: ComponentConfig[] = [
+  {
+    children: [
+      {
+        children: [
+          {
+            component: MDX.LungMAPDataReleasePolicy,
+          } as ComponentConfig<typeof MDX.LungMAPDataReleasePolicy>,
+        ],
+        component: MDX.Section,
+      } as ComponentConfig<typeof MDX.Section>,
+    ],
+    component: C.FluidPaper,
+  } as ComponentConfig<typeof C.FluidPaper>,
+];

--- a/explorer/site-config/lungmap/dev/detail/project/exportSideColumn.ts
+++ b/explorer/site-config/lungmap/dev/detail/project/exportSideColumn.ts
@@ -1,6 +1,6 @@
 import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "../../../../../app/components";
-import * as MDX from "../../../../../app/content";
+import * as MDX from "../../../../../app/content/lungmap";
 
 export const sideColumn: ComponentConfig[] = [
   {
@@ -8,8 +8,8 @@ export const sideColumn: ComponentConfig[] = [
       {
         children: [
           {
-            component: MDX.LungMAPDataReleasePolicy,
-          } as ComponentConfig<typeof MDX.LungMAPDataReleasePolicy>,
+            component: MDX.DataReleasePolicy,
+          } as ComponentConfig<typeof MDX.DataReleasePolicy>,
         ],
         component: MDX.Section,
       } as ComponentConfig<typeof MDX.Section>,

--- a/explorer/site-config/lungmap/dev/detail/project/matricesSideColumn.ts
+++ b/explorer/site-config/lungmap/dev/detail/project/matricesSideColumn.ts
@@ -1,0 +1,19 @@
+import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
+import * as C from "../../../../../app/components";
+import * as MDX from "../../../../../app/content";
+
+export const sideColumn: ComponentConfig[] = [
+  {
+    children: [
+      {
+        children: [
+          {
+            component: MDX.LungMAPDataReleasePolicy,
+          } as ComponentConfig<typeof MDX.LungMAPDataReleasePolicy>,
+        ],
+        component: MDX.Section,
+      } as ComponentConfig<typeof MDX.Section>,
+    ],
+    component: C.FluidPaper,
+  } as ComponentConfig<typeof C.FluidPaper>,
+];

--- a/explorer/site-config/lungmap/dev/detail/project/matricesSideColumn.ts
+++ b/explorer/site-config/lungmap/dev/detail/project/matricesSideColumn.ts
@@ -1,6 +1,6 @@
 import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "../../../../../app/components";
-import * as MDX from "../../../../../app/content";
+import * as MDX from "../../../../../app/content/lungmap";
 
 export const sideColumn: ComponentConfig[] = [
   {
@@ -8,8 +8,8 @@ export const sideColumn: ComponentConfig[] = [
       {
         children: [
           {
-            component: MDX.LungMAPDataReleasePolicy,
-          } as ComponentConfig<typeof MDX.LungMAPDataReleasePolicy>,
+            component: MDX.DataReleasePolicy,
+          } as ComponentConfig<typeof MDX.DataReleasePolicy>,
         ],
         component: MDX.Section,
       } as ComponentConfig<typeof MDX.Section>,

--- a/explorer/site-config/lungmap/dev/detail/project/metadataSideColumn.ts
+++ b/explorer/site-config/lungmap/dev/detail/project/metadataSideColumn.ts
@@ -1,0 +1,19 @@
+import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
+import * as C from "../../../../../app/components";
+import * as MDX from "../../../../../app/content";
+
+export const sideColumn: ComponentConfig[] = [
+  {
+    children: [
+      {
+        children: [
+          {
+            component: MDX.LungMAPDataReleasePolicy,
+          } as ComponentConfig<typeof MDX.LungMAPDataReleasePolicy>,
+        ],
+        component: MDX.Section,
+      } as ComponentConfig<typeof MDX.Section>,
+    ],
+    component: C.FluidPaper,
+  } as ComponentConfig<typeof C.FluidPaper>,
+];

--- a/explorer/site-config/lungmap/dev/detail/project/metadataSideColumn.ts
+++ b/explorer/site-config/lungmap/dev/detail/project/metadataSideColumn.ts
@@ -1,6 +1,6 @@
 import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "../../../../../app/components";
-import * as MDX from "../../../../../app/content";
+import * as MDX from "../../../../../app/content/lungmap";
 
 export const sideColumn: ComponentConfig[] = [
   {
@@ -8,8 +8,8 @@ export const sideColumn: ComponentConfig[] = [
       {
         children: [
           {
-            component: MDX.LungMAPDataReleasePolicy,
-          } as ComponentConfig<typeof MDX.LungMAPDataReleasePolicy>,
+            component: MDX.DataReleasePolicy,
+          } as ComponentConfig<typeof MDX.DataReleasePolicy>,
         ],
         component: MDX.Section,
       } as ComponentConfig<typeof MDX.Section>,

--- a/explorer/site-config/lungmap/dev/detail/project/projectFilesSideColumn.ts
+++ b/explorer/site-config/lungmap/dev/detail/project/projectFilesSideColumn.ts
@@ -1,0 +1,19 @@
+import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
+import * as C from "../../../../../app/components";
+import * as MDX from "../../../../../app/content";
+
+export const sideColumn: ComponentConfig[] = [
+  {
+    children: [
+      {
+        children: [
+          {
+            component: MDX.LungMAPDataReleasePolicy,
+          } as ComponentConfig<typeof MDX.LungMAPDataReleasePolicy>,
+        ],
+        component: MDX.Section,
+      } as ComponentConfig<typeof MDX.Section>,
+    ],
+    component: C.FluidPaper,
+  } as ComponentConfig<typeof C.FluidPaper>,
+];

--- a/explorer/site-config/lungmap/dev/detail/project/projectFilesSideColumn.ts
+++ b/explorer/site-config/lungmap/dev/detail/project/projectFilesSideColumn.ts
@@ -1,6 +1,6 @@
 import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "../../../../../app/components";
-import * as MDX from "../../../../../app/content";
+import * as MDX from "../../../../../app/content/lungmap";
 
 export const sideColumn: ComponentConfig[] = [
   {
@@ -8,8 +8,8 @@ export const sideColumn: ComponentConfig[] = [
       {
         children: [
           {
-            component: MDX.LungMAPDataReleasePolicy,
-          } as ComponentConfig<typeof MDX.LungMAPDataReleasePolicy>,
+            component: MDX.DataReleasePolicy,
+          } as ComponentConfig<typeof MDX.DataReleasePolicy>,
         ],
         component: MDX.Section,
       } as ComponentConfig<typeof MDX.Section>,

--- a/explorer/site-config/lungmap/dev/export/exportConfig.ts
+++ b/explorer/site-config/lungmap/dev/export/exportConfig.ts
@@ -3,7 +3,7 @@ import {
   ComponentConfig,
 } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "../../../../app/components";
-import * as MDX from "../../../../app/content";
+import * as MDX from "../../../../app/content/lungmap";
 import { exportConfig as hcaExportConfig } from "../../../hca-dcp/dev/export/export";
 
 export const exportConfig: BackPageConfig = {
@@ -17,8 +17,8 @@ export const exportConfig: BackPageConfig = {
             {
               children: [
                 {
-                  component: MDX.LungMAPDataReleasePolicy,
-                } as ComponentConfig<typeof MDX.LungMAPDataReleasePolicy>,
+                  component: MDX.DataReleasePolicy,
+                } as ComponentConfig<typeof MDX.DataReleasePolicy>,
               ],
               component: MDX.Section,
             } as ComponentConfig<typeof MDX.Section>,

--- a/explorer/site-config/lungmap/dev/export/exportConfig.ts
+++ b/explorer/site-config/lungmap/dev/export/exportConfig.ts
@@ -1,0 +1,31 @@
+import {
+  BackPageConfig,
+  ComponentConfig,
+} from "@clevercanary/data-explorer-ui/lib/config/entities";
+import * as C from "../../../../app/components";
+import * as MDX from "../../../../app/content";
+import { exportConfig as hcaExportConfig } from "../../../hca-dcp/dev/export/export";
+
+export const exportConfig: BackPageConfig = {
+  ...hcaExportConfig,
+  tabs: [
+    {
+      ...hcaExportConfig.tabs[0],
+      sideColumn: [
+        {
+          children: [
+            {
+              children: [
+                {
+                  component: MDX.LungMAPDataReleasePolicy,
+                } as ComponentConfig<typeof MDX.LungMAPDataReleasePolicy>,
+              ],
+              component: MDX.Section,
+            } as ComponentConfig<typeof MDX.Section>,
+          ],
+          component: C.FluidPaper,
+        } as ComponentConfig<typeof C.FluidPaper>,
+      ],
+    },
+  ],
+};

--- a/explorer/site-config/lungmap/dev/index/projectsEntityConfig.ts
+++ b/explorer/site-config/lungmap/dev/index/projectsEntityConfig.ts
@@ -1,0 +1,54 @@
+import { EntityConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
+import { mainColumn as hcaExportMainColumn } from "../../../hca-dcp/dev/detail/project/exportMainColumn";
+import { mainColumn as hcaMatricesMainColumn } from "../../../hca-dcp/dev/detail/project/matricesMainColumn";
+import { mainColumn as hcaMetadataMainColumn } from "../../../hca-dcp/dev/detail/project/metadataMainColumn";
+import { mainColumn as hcaOverviewMainColumn } from "../../../hca-dcp/dev/detail/project/overviewMainColumn";
+import { sideColumn as hcaOverviewSideColumn } from "../../../hca-dcp/dev/detail/project/overviewSideColumn";
+import { mainColumn as hcaProjectFilesMainColumn } from "../../../hca-dcp/dev/detail/project/projectFilesMainColumn";
+import { projectsEntity as hcaProjectsEntity } from "../../../hca-dcp/dev/projectsEntity";
+import { sideColumn as exportSideColumn } from "../detail/project/exportSideColumn";
+import { sideColumn as matricesSideColumn } from "../detail/project/matricesSideColumn";
+import { sideColumn as metadataSideColumn } from "../detail/project/metadataSideColumn";
+import { sideColumn as projectFilesSideColumn } from "../detail/project/projectFilesSideColumn";
+
+/**
+ * Entity config object responsible to config anything related to the /explore/projects route.
+ */
+export const projectsEntityConfig: EntityConfig = {
+  ...hcaProjectsEntity,
+  detail: {
+    ...hcaProjectsEntity.detail,
+    tabs: [
+      {
+        label: "Overview",
+        mainColumn: hcaOverviewMainColumn,
+        route: "",
+        sideColumn: hcaOverviewSideColumn,
+      },
+      {
+        label: "Metadata",
+        mainColumn: hcaMetadataMainColumn,
+        route: "project-metadata",
+        sideColumn: metadataSideColumn,
+      },
+      {
+        label: "Matrices",
+        mainColumn: hcaMatricesMainColumn,
+        route: "project-matrices",
+        sideColumn: matricesSideColumn,
+      },
+      {
+        label: "Project Files",
+        mainColumn: hcaProjectFilesMainColumn,
+        route: "get-curl-command",
+        sideColumn: projectFilesSideColumn,
+      },
+      {
+        label: "Export",
+        mainColumn: hcaExportMainColumn,
+        route: "export-to-terra",
+        sideColumn: exportSideColumn,
+      },
+    ],
+  },
+};


### PR DESCRIPTION
### Ticket
Closes #700 

### Reviewers
@NoopDog 

### Changes
- Added data use policy.

### Definition of Done (from ticket)
- Data use policy added with links as per [mock]() as per HCA [production](https://data.humancellatlas.org/explore/projects/f86f1ab4-1fbb-4510-ae35-3ffd752d4dfc/project-matrices) and per LungMAP [production](https://data-browser.lungmap.net/explore/projects/1bdcecde-16be-4208-88f4-78cd2133d11d/m/project-matrices).

### Known Issues
- External links should be opened with target="_blank".
- Export To Terra page currently does not have a configuration for the side column. One possible solution is to share the `exportConfig` `sideColumn` for each of the export pages. Let's discuss.