### PR TITLE
feat: view project accessions (#746)

### DIFF
--- a/explorer/app/components/index.tsx
+++ b/explorer/app/components/index.tsx
@@ -5,6 +5,8 @@ export {
   DownloadIconSmall,
   InventoryIconSmall,
 } from "@clevercanary/data-explorer-ui/lib/components/common/CustomIcon/common/constants";
+export { GridItem } from "@clevercanary/data-explorer-ui/lib/components/common/Grid/components/GridItem/gridItem";
+export { Grid } from "@clevercanary/data-explorer-ui/lib/components/common/Grid/grid";
 export { KeyElType } from "@clevercanary/data-explorer-ui/lib/components/common/KeyValuePairs/components/KeyElType/keyElType";
 export { ValueElType } from "@clevercanary/data-explorer-ui/lib/components/common/KeyValuePairs/components/ValueElType/valueElType";
 export { KeyValuePairs } from "@clevercanary/data-explorer-ui/lib/components/common/KeyValuePairs/keyValuePairs";
@@ -12,6 +14,7 @@ export { Markdown } from "@clevercanary/data-explorer-ui/lib/components/common/M
 export { FluidPaper } from "@clevercanary/data-explorer-ui/lib/components/common/Paper/paper.styles";
 export { CollapsableSection } from "@clevercanary/data-explorer-ui/lib/components/common/Section/components/CollapsableSection/collapsableSection";
 export { GridPaperSection } from "@clevercanary/data-explorer-ui/lib/components/common/Section/section.styles";
+export { Divider } from "@clevercanary/data-explorer-ui/lib/components/common/Stack/components/Divider/divider";
 export { Stack } from "@clevercanary/data-explorer-ui/lib/components/common/Stack/stack";
 export { StaticImage } from "@clevercanary/data-explorer-ui/lib/components/common/StaticImage/staticImage";
 export { DetailViewTable } from "@clevercanary/data-explorer-ui/lib/components/Detail/components/DetailViewTable/detailViewTable";

--- a/explorer/app/models/responses.ts
+++ b/explorer/app/models/responses.ts
@@ -1,4 +1,12 @@
 /**
+ * Model of accessions included in the response from index/projects or /projects/uuid API endpoints.
+ */
+export interface AccessionResponse {
+  accession: string;
+  namespace: string;
+}
+
+/**
  * Model of contributor value included in the response from index/projects API endpoint.
  */
 export interface ContributorResponse {
@@ -27,6 +35,7 @@ export type ProjectResponseMatrices = { [key: string]: unknown };
  * Model of project value nested in response returned from index/projects API endpoint.
  */
 export interface ProjectResponse {
+  accessions: AccessionResponse[];
   contributedAnalyses: ProjectResponseContributedAnalyses;
   contributors: ContributorResponse[];
   estimatedCellCount: number;

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/accessionMapper/accessionMapper.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/accessionMapper/accessionMapper.ts
@@ -1,0 +1,84 @@
+import { AccessionResponse } from "../../../../../models/responses";
+import {
+  ACCESSION_CONFIGS_BY_RESPONSE_KEY,
+  IDENTIFIERS_ORG_URL,
+} from "./constants";
+import {
+  Accession,
+  AccessionConfig,
+  AccessionConfigKeys,
+  AccessionsByLabel,
+} from "./entities";
+
+/**
+ * Group accession configs by the given key.
+ * @param groupBy - Keys of accession config object.
+ * @param configs - Accession configurations.
+ * @returns accession configs grouped by the given key.
+ */
+export function groupAccessionBy(
+  groupBy: AccessionConfigKeys,
+  configs: AccessionConfig[]
+): Map<string, AccessionConfig> {
+  return configs.reduce((accum, config) => {
+    accum.set(config[groupBy], config);
+    return accum;
+  }, new Map<string, AccessionConfig>());
+}
+
+/**
+ * Convert array of accessions into map keyed by accession namespace.
+ * @param accessionsResponse - Project accessions returned in response.
+ * @returns map of accessions keyed by accession namespace.
+ */
+export function mapAccessions(
+  accessionsResponse?: AccessionResponse[]
+): AccessionsByLabel {
+  if (!accessionsResponse) {
+    return new Map();
+  }
+  // Key accessions returned in response by accession label (e.g. Array Express Accessions)
+  return accessionsResponse.reduce((accum, accessionResponse) => {
+    if (!accessionResponse) {
+      return accum;
+    }
+    const config = ACCESSION_CONFIGS_BY_RESPONSE_KEY.get(
+      accessionResponse.namespace
+    );
+    if (!config) {
+      return accum;
+    }
+    const { label } = config;
+    if (!accum.has(label)) {
+      accum.set(label, []);
+    }
+    // Accession is a semi colon-separated (possibly followed by whitespace) string of accession values
+    accessionResponse.accession.split(";").forEach((id) => {
+      // Add FE-specific model of accession
+      const trimmedId = id.trim();
+      accum.get(label)?.push({
+        id: trimmedId,
+        label,
+        url: transformAccessionURL(trimmedId, config.identifierOrgPrefix),
+      });
+    });
+    return accum;
+  }, new Map<string, Accession[]>());
+}
+
+/**
+ * Converts the accession into the format ${IDENTIFIERS_ORG_PATH}/${ACCESSION_PATH}:${ACCESSION}.
+ * @param accessionId - Accession identifier.
+ * @param identifierOrgPrefix - Identifier org prefix.
+ * @returns formatted accession URL.
+ */
+function transformAccessionURL(
+  accessionId: string,
+  identifierOrgPrefix: string
+): string {
+  console.log(accessionId, identifierOrgPrefix);
+  if (!accessionId || !identifierOrgPrefix) {
+    return "";
+  }
+  return `${IDENTIFIERS_ORG_URL}/${identifierOrgPrefix}:${accessionId}`;
+}

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/accessionMapper/constants.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/accessionMapper/constants.ts
@@ -1,0 +1,51 @@
+import { groupAccessionBy } from "./accessionMapper";
+import { AccessionConfig } from "./entities";
+
+/* Accession configuration values */
+export const ACCESSION_CONFIGS: AccessionConfig[] = [
+  {
+    identifierOrgPrefix: "arrayexpress",
+    label: "Array Express Accessions",
+    responseKey: "array_express",
+  },
+  {
+    identifierOrgPrefix: "biostudies",
+    label: "BioStudies Accessions",
+    responseKey: "biostudies",
+  },
+  {
+    identifierOrgPrefix: "ega.study",
+    label: "EGA Accessions",
+    responseKey: "ega",
+  },
+  {
+    identifierOrgPrefix: "dpgap",
+    label: "dbGaP Accessions",
+    responseKey: "dpgap",
+  },
+  {
+    identifierOrgPrefix: "geo",
+    label: "GEO Series Accessions",
+    responseKey: "geo_series",
+  },
+  {
+    identifierOrgPrefix: "ena.embl",
+    label: "INSDC Project Accessions",
+    responseKey: "insdc_project",
+  },
+  {
+    identifierOrgPrefix: "ena.embl",
+    label: "INSDC Study Accessions",
+    responseKey: "insdc_study",
+  },
+];
+
+/**
+ * Build up map of accession configs keyed by response key.
+ */
+export const ACCESSION_CONFIGS_BY_RESPONSE_KEY = groupAccessionBy(
+  "responseKey",
+  ACCESSION_CONFIGS
+);
+
+export const IDENTIFIERS_ORG_URL = "https://identifiers.org";

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/accessionMapper/entities.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/accessionMapper/entities.ts
@@ -1,0 +1,28 @@
+/**
+ * Model of accession, including URL, associated with a project.
+ */
+export interface Accession {
+  id: string; // Accession value
+  label: string; // Accession namespace
+  url: string;
+}
+
+/**
+ * Model of accession configuration, used when mapping accession values returned from /projects and /projects/uuid
+ * endpoints into FE-specific model.
+ */
+export interface AccessionConfig {
+  identifierOrgPrefix: string;
+  label: string;
+  responseKey: string;
+}
+
+/**
+ * Keys of accession config object - used when grouping accession configs by different values
+ */
+export type AccessionConfigKeys = keyof AccessionConfig;
+
+/**
+ * Accessions keyed by accession namespace.
+ */
+export type AccessionsByLabel = Map<string, Accession[]>;

--- a/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders.ts
@@ -1,5 +1,10 @@
+import {
+  Key,
+  Value,
+} from "@clevercanary/data-explorer-ui/lib/components/common/KeyValuePairs/keyValuePairs";
+import { ANCHOR_TARGET } from "@clevercanary/data-explorer-ui/lib/components/Links/common/entities";
 import { ColumnDef } from "@tanstack/react-table";
-import React from "react";
+import React, { Fragment, ReactElement } from "react";
 import {
   HCA_DCP_CATEGORY_KEY,
   HCA_DCP_CATEGORY_LABEL,
@@ -31,10 +36,41 @@ import {
   ProjectMatrixTableView,
   ProjectMatrixView,
 } from "../../common/entities";
+import { mapAccessions } from "./accessionMapper/accessionMapper";
+import { Accession } from "./accessionMapper/entities";
 import {
   groupProjectMatrixViewsBySpecies,
   projectMatrixMapper,
 } from "./projectMatrixMapper";
+
+/**
+ * Build props for the KeyValuePairs component for displaying the project accessions.
+ * @param projectsResponse - Response model return from projects API.
+ * @returns model to be used as props for the key value pairs component.
+ */
+export const buildAccessions = (
+  projectsResponse: ProjectsResponse
+): React.ComponentProps<typeof C.KeyValuePairs> => {
+  const project = getProjectResponse(projectsResponse);
+  const accessionsByLabel = mapAccessions(project?.accessions);
+  const keyValuePairs = new Map<Key, Value>();
+  for (const [label, accessions] of accessionsByLabel) {
+    keyValuePairs.set(`${label}:`, getAccessionsKeyValue(accessions));
+  }
+  return {
+    KeyElType: (props) =>
+      C.KeyElType({
+        color: "ink.main",
+        ...props,
+      }),
+    KeyValueElType: Fragment,
+    KeyValuesElType: (props) =>
+      C.Grid({ gap: 1, gridTemplateColumns: "auto 1fr", ...props }),
+    ValueElType: (props) =>
+      C.GridItem({ display: "flex", flexWrap: "wrap", ...props }),
+    keyValuePairs,
+  };
+};
 
 /**
  * Build props for the data normalization and batch correction alert component.
@@ -200,6 +236,24 @@ export const filesBuildCellCount = (
     value: Transformers.filesGetCellCount(file),
   };
 };
+
+/**
+ * Returns the KeyValuePair value for the accessions.
+ * @param accessions - Accessions.
+ * @returns the KeyValuePair value for the accessions as a ReactElement.
+ */
+function getAccessionsKeyValue(accessions: Accession[]): ReactElement {
+  return C.Links({
+    divider: C.Divider({ children: ", " }),
+    links: accessions.map(({ id, url }) => {
+      return {
+        label: id,
+        target: ANCHOR_TARGET.BLANK,
+        url,
+      };
+    }),
+  });
+}
 
 // Samples view builders
 

--- a/explorer/package-lock.json
+++ b/explorer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "explorer",
       "version": "0.1.0",
       "dependencies": {
-        "@clevercanary/data-explorer-ui": "0.3.0",
+        "@clevercanary/data-explorer-ui": "0.5.2",
         "@emotion/react": "11.10.4",
         "@emotion/styled": "11.10.4",
         "@mdx-js/loader": "^2.3.0",
@@ -1977,9 +1977,9 @@
       "dev": true
     },
     "node_modules/@clevercanary/data-explorer-ui": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.3.0.tgz",
-      "integrity": "sha512-XoNoPYwT5IP/bsCriPucBDDvXFe4R7eXC2lAm/6v25zeGq8V0GKXfGE7c6MtgZTwceKzFVYYUNswhQiuz6muGg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.5.2.tgz",
+      "integrity": "sha512-LvobQQeUmHSG61bhMTSv+3AIqM+psdA9UhDV+H+A25rqf1mVmh0Fb8HG4DTp/0BwR18QIdKbeNmKVQcMm8mUkQ==",
       "peerDependencies": {
         "@emotion/react": "11.10.4",
         "@emotion/styled": "11.10.4",
@@ -34609,9 +34609,9 @@
       "dev": true
     },
     "@clevercanary/data-explorer-ui": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.3.0.tgz",
-      "integrity": "sha512-XoNoPYwT5IP/bsCriPucBDDvXFe4R7eXC2lAm/6v25zeGq8V0GKXfGE7c6MtgZTwceKzFVYYUNswhQiuz6muGg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@clevercanary/data-explorer-ui/-/data-explorer-ui-0.5.2.tgz",
+      "integrity": "sha512-LvobQQeUmHSG61bhMTSv+3AIqM+psdA9UhDV+H+A25rqf1mVmh0Fb8HG4DTp/0BwR18QIdKbeNmKVQcMm8mUkQ==",
       "requires": {}
     },
     "@cnakazawa/watch": {

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -29,7 +29,7 @@
     "test:anvil-catalog": "playwright test -c playwright_anvil-catalog.config.ts"
   },
   "dependencies": {
-    "@clevercanary/data-explorer-ui": "0.3.0",
+    "@clevercanary/data-explorer-ui": "0.5.2",
     "@emotion/react": "11.10.4",
     "@emotion/styled": "11.10.4",
     "@mdx-js/loader": "^2.3.0",

--- a/explorer/site-config/hca-dcp/dev/detail/project/overviewMainColumn.ts
+++ b/explorer/site-config/hca-dcp/dev/detail/project/overviewMainColumn.ts
@@ -1,7 +1,8 @@
 import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
 import * as C from "app/components";
 import { ProjectsResponse } from "app/models/responses";
-import * as T from "../../projectViewModelBuilder";
+import * as V from "../../../../../app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders";
+import * as T from "../../projectViewModelBuilder"; // TODO refactor to "app/viewModelBuilders/azul/hca-dcp/common/viewModelBuilders"
 
 export const mainColumn = [
   {
@@ -36,6 +37,19 @@ export const mainColumn = [
     component: C.SupplementaryLinks,
     viewBuilder: T.buildSupplementaryLinks,
   } as ComponentConfig<typeof C.SupplementaryLinks>,
+  {
+    children: [
+      {
+        component: C.KeyValuePairs,
+        viewBuilder: V.buildAccessions,
+      } as ComponentConfig<typeof C.KeyValuePairs, ProjectsResponse>,
+    ],
+    component: C.CollapsableSection,
+    props: {
+      collapsable: true,
+      title: "Accessions",
+    },
+  } as ComponentConfig<typeof C.CollapsableSection>,
   {
     component: C.DataReleasePolicy,
   } as ComponentConfig<typeof C.DataReleasePolicy>,


### PR DESCRIPTION
### Ticket
Closes #746.

### Reviewers
@MillenniumFalconMechanic.

### Changes
- Added project accessions to detailed project overview page.

### Definition of Done (from ticket)
- Project accessions are displayed on the project overview detail page.

### QA steps (optional)
- Package upgrade to `v0.5.2`.

### Known Issues
- Let's review the folder structure for `accessionMapper` and decide whether we should emulate this for `projectMatrixMapper`.