### PR TITLE
feat: add consortia descriptions text to consortia detail pages (#769)

### DIFF
--- a/explorer/app/content/anvil-catalog/consortia/1000g.mdx
+++ b/explorer/app/content/anvil-catalog/consortia/1000g.mdx
@@ -1,0 +1,1 @@
+The 1000 Genomes Project, launched in January 2008, is an international research effort to establish variation profiles across the human population. This open access data set continues to be a valuable resource to geneticists.

--- a/explorer/app/content/anvil-catalog/consortia/ccdg.mdx
+++ b/explorer/app/content/anvil-catalog/consortia/ccdg.mdx
@@ -1,0 +1,1 @@
+The Centers for Common Disease Genomics are a collaborative large-scale genome sequencing effort to comprehensively identify rare risk and protective variants contributing to multiple common disease phenotypes.

--- a/explorer/app/content/anvil-catalog/consortia/cmg.mdx
+++ b/explorer/app/content/anvil-catalog/consortia/cmg.mdx
@@ -1,0 +1,1 @@
+The Centers for Mendelian Genomics is a multi-center collaboration aimed at identifying the genes responsible for Mendelian phenotypes by whole exome and whole genome sequencing.

--- a/explorer/app/content/anvil-catalog/consortia/consortium.mdx
+++ b/explorer/app/content/anvil-catalog/consortia/consortium.mdx
@@ -1,0 +1,18 @@
+import { Link } from "@clevercanary/data-explorer-ui/lib/components/Links/components/Link/link";
+
+The description of this consortium is under development for additional information.
+
+Please reach out to [help@lists.anvilproject.org](mailto:help@lists.anvilproject.org) for additional information.
+
+<div>
+  Meanwhile, please view the consortium's{" "}
+  <Link
+    label="studies"
+    url={props.consortium ? `/consortia/${props.consortium}/studies` : ""}
+  />{" "}
+  and
+  <Link
+    label="workspaces"
+    url={props.consortium ? `/consortia/${props.consortium}/workspaces` : ""}
+  />.
+</div>

--- a/explorer/app/content/anvil-catalog/consortia/cser.mdx
+++ b/explorer/app/content/anvil-catalog/consortia/cser.mdx
@@ -1,0 +1,1 @@
+The Clinical Sequencing Evidence-Generating Research (CSER) consortium is a national multi-site research program funded by the National Human Genome Research Institute (NHGRI), the National Cancer Institute (NCI), and the National Institute on Minority Health and Health Disparities (NIMHD).

--- a/explorer/app/content/anvil-catalog/consortia/emerge.mdx
+++ b/explorer/app/content/anvil-catalog/consortia/emerge.mdx
@@ -1,0 +1,1 @@
+The Electronic and MEdical Records and Genomics project (eMERGE) is a national network organized and funded by the NHGRI that combines DNA biorepositories with electronic medical record (EMR) systems for large scale, high-throughput genetic research in support of implementing genomic medicine.

--- a/explorer/app/content/anvil-catalog/consortia/gtex.mdx
+++ b/explorer/app/content/anvil-catalog/consortia/gtex.mdx
@@ -1,0 +1,1 @@
+The Genotype-Tissue Expression (GTEx) project is an ongoing effort to build a comprehensive public resource to study tissue-specific gene expression and regulation. Samples were collected from 54 non-diseased tissue sites across nearly 1000 individuals, primarily for molecular assays including WGS, WES, and RNA-Seq.

--- a/explorer/app/content/anvil-catalog/consortia/hprc.mdx
+++ b/explorer/app/content/anvil-catalog/consortia/hprc.mdx
@@ -1,0 +1,1 @@
+The Human Pangenome Reference Consortium aims to modernize the human reference to include a collection of diverse and highly accurate, haplotype-phased genome assemblies. This initiative will generate new technical standards in genome sequencing, scalable and reproducible assembly methods, and pangenomic tool development to ensure comprehensive variant discovery.

--- a/explorer/app/content/anvil-catalog/consortia/page.mdx
+++ b/explorer/app/content/anvil-catalog/consortia/page.mdx
@@ -1,0 +1,1 @@
+The Population Architecture Using Genomics and Epidemiology Consortium investigates ancestrally diverse populations to gain a better understanding of how genetic factors influence susceptibility to disease.

--- a/explorer/app/content/anvil-catalog/index.tsx
+++ b/explorer/app/content/anvil-catalog/index.tsx
@@ -1,0 +1,11 @@
+export { RenderComponent } from "@clevercanary/data-explorer-ui/lib/components/ComponentCreator/components/RenderComponent/renderComponent";
+export { Section } from "../../components/common/MDXMarkdown/components/Section/mdxSection.styles";
+export { default as ThousandG } from "./consortia/1000g.mdx";
+export { default as CCDG } from "./consortia/ccdg.mdx";
+export { default as CMG } from "./consortia/cmg.mdx";
+export { default as ConsortiumInDevelopment } from "./consortia/consortium.mdx";
+export { default as CSER } from "./consortia/cser.mdx";
+export { default as EMERGE } from "./consortia/emerge.mdx";
+export { default as GTEX } from "./consortia/gtex.mdx";
+export { default as HPRC } from "./consortia/hprc.mdx";
+export { default as PAGE } from "./consortia/page.mdx";

--- a/explorer/app/viewModelBuilders/catalog/anvil-catalog/common/viewModelBuilders.ts
+++ b/explorer/app/viewModelBuilders/catalog/anvil-catalog/common/viewModelBuilders.ts
@@ -12,6 +12,7 @@ import {
   ANVIL_CATALOG_CATEGORY_KEY,
   ANVIL_CATALOG_CATEGORY_LABEL,
 } from "../../../../../site-config/anvil-catalog/category";
+import { CONSORTIUM } from "../../../../../site-config/anvil-catalog/dev/index/common/constants";
 import {
   AnVILCatalogConsortium,
   AnVILCatalogConsortiumStudy,
@@ -22,6 +23,7 @@ import {
 import * as C from "../../../../components";
 import { METADATA_KEY } from "../../../../components/Index/common/entities";
 import { getPluralizedMetadataLabel } from "../../../../components/Index/common/indexTransformer";
+import * as MDX from "../../../../content/anvil-catalog";
 
 /**
  * Build props for consent code cell component from the given AnVIL workspace.
@@ -61,7 +63,8 @@ export const buildConsortium = (
   const { consortium } = anVILCatalogEntity;
   return {
     label: consortium,
-    url: `/consortia/${consortium}`,
+    url:
+      consortium === CONSORTIUM.UNSPECIFIED ? "" : `/consortia/${consortium}`,
   };
 };
 
@@ -97,6 +100,69 @@ export const buildConsortiumDetailViewWorkspacesTable = (
     items: workspaces,
     noResultsTitle: "No Workspaces",
   };
+};
+
+/**
+ * Build props for consortium overview component from the given AnVIL entity.
+ * @param anVILCatalogConsortium - AnVil catalog consortium.
+ * @returns model to be used as props for the consortium overview component.
+ */
+export const buildConsortiumOverview = (
+  anVILCatalogConsortium: AnVILCatalogConsortium
+): React.ComponentProps<typeof MDX.RenderComponent> => {
+  switch (anVILCatalogConsortium.consortium) {
+    case CONSORTIUM.CCDG:
+      return { Component: MDX.CCDG };
+    case CONSORTIUM.CMG:
+      return { Component: MDX.CMG };
+    case CONSORTIUM.CMH:
+      return {
+        Component: () =>
+          MDX.ConsortiumInDevelopment({
+            consortium: CONSORTIUM.CMH,
+          }),
+      };
+    case CONSORTIUM.CONVERGENT_NEUROSCIENCE:
+      return {
+        Component: () =>
+          MDX.ConsortiumInDevelopment({
+            consortium: CONSORTIUM.CONVERGENT_NEUROSCIENCE,
+          }),
+      };
+    case CONSORTIUM.CSER:
+      return { Component: MDX.CSER };
+    case CONSORTIUM.EMERGE:
+      return { Component: MDX.EMERGE };
+    case CONSORTIUM.GTEX:
+      return { Component: MDX.GTEX };
+    case CONSORTIUM.HPRC:
+      return { Component: MDX.HPRC };
+    case CONSORTIUM.PAGE:
+      return { Component: MDX.PAGE };
+    case CONSORTIUM.T2T:
+      return {
+        Component: () =>
+          MDX.ConsortiumInDevelopment({
+            consortium: CONSORTIUM.T2T,
+          }),
+      };
+    case CONSORTIUM.WGSPD1:
+      return {
+        Component: () =>
+          MDX.ConsortiumInDevelopment({
+            consortium: CONSORTIUM.WGSPD1,
+          }),
+      };
+    case CONSORTIUM["1000G"]:
+      return { Component: MDX.ThousandG };
+    default:
+      return {
+        Component: () =>
+          MDX.ConsortiumInDevelopment({
+            consortium: undefined,
+          }),
+      };
+  }
 };
 
 /**

--- a/explorer/site-config/anvil-catalog/dev/detail/consortium/overviewMainColumn.ts
+++ b/explorer/site-config/anvil-catalog/dev/detail/consortium/overviewMainColumn.ts
@@ -1,1 +1,21 @@
-export const mainColumn = [];
+import { ComponentConfig } from "@clevercanary/data-explorer-ui/lib/config/entities";
+import * as C from "../../../../../app/components/index";
+import * as MDX from "../../../../../app/content/anvil-catalog";
+import * as V from "../../../../../app/viewModelBuilders/catalog/anvil-catalog/common/viewModelBuilders";
+
+export const mainColumn = [
+  {
+    children: [
+      {
+        children: [
+          {
+            component: MDX.RenderComponent,
+            viewBuilder: V.buildConsortiumOverview,
+          } as ComponentConfig<typeof MDX.RenderComponent>,
+        ],
+        component: MDX.Section,
+      } as ComponentConfig<typeof MDX.Section>,
+    ],
+    component: C.FluidPaper,
+  } as ComponentConfig<typeof C.FluidPaper>,
+];

--- a/explorer/site-config/anvil-catalog/dev/index/common/constants.ts
+++ b/explorer/site-config/anvil-catalog/dev/index/common/constants.ts
@@ -1,0 +1,15 @@
+export enum CONSORTIUM {
+  "1000G" = "1000G",
+  CCDG = "CCDG",
+  CMG = "CMG",
+  CMH = "CMH",
+  CONVERGENT_NEUROSCIENCE = "Convergent Neuroscience",
+  CSER = "CSER",
+  EMERGE = "eMERGE",
+  GTEX = "GTEx",
+  HPRC = "HPRC",
+  PAGE = "PAGE",
+  T2T = "T2T",
+  UNSPECIFIED = "Unspecified",
+  WGSPD1 = "WGSPD1",
+}

--- a/explorer/site-config/anvil-catalog/dev/index/consortiaEntityConfig.ts
+++ b/explorer/site-config/anvil-catalog/dev/index/consortiaEntityConfig.ts
@@ -25,7 +25,7 @@ import { workspacesMainColumn } from "../detail/consortium/workspacesMainColumn"
  */
 export const consortiaEntityConfig: EntityConfig<AnVILCatalogConsortium> = {
   detail: {
-    detailOverviews: ["Overview"],
+    detailOverviews: [],
     staticLoad: true,
     tabs: [
       {


### PR DESCRIPTION
### Ticket
Closes #769.

### Reviewers
@NoopDog.

### Changes
- Added consortia descriptions to consortia detail pages.

### Definition of Done (from ticket)
- Consortia descriptions rendered on the corresponding detail page.
